### PR TITLE
Selective AllBrowsersPerSharedTest

### DIFF
--- a/src/main/scala/org/scalatestplus/play/AllBrowsersPerSharedTest.scala
+++ b/src/main/scala/org/scalatestplus/play/AllBrowsersPerSharedTest.scala
@@ -164,7 +164,7 @@ trait AllBrowsersPerSharedTest extends SuiteMixin with WebBrowser with Eventuall
    */
   protected lazy val browsers: IndexedSeq[BrowserInfo] =
     Vector(
-      new FirefoxInfo(firefoxProfile),
+      FirefoxInfo(firefoxProfile),
       SafariInfo,
       InternetExplorerInfo,
       ChromeInfo,

--- a/src/test/scala/org/scalatestplus/play/AllBrowsersPerSharedTestBehaviorSpec.scala
+++ b/src/test/scala/org/scalatestplus/play/AllBrowsersPerSharedTestBehaviorSpec.scala
@@ -247,7 +247,7 @@ class AllBrowsersPerSharedTestBehaviorSpec extends WordSpec {
       class FirefoxTestSpec extends TestSpec {
         override lazy val browsers: IndexedSeq[BrowserInfo] =
           Vector(
-            new FirefoxInfo(firefoxProfile)
+            FirefoxInfo(firefoxProfile)
           )
       }
 


### PR DESCRIPTION
Added tests to AllBrowsersPerSharedTestBehaviorSpec to make sure user can override browsers to choose browser(s) to run, and this requires to make the browsers field in AllBrowsersPerSharedTest as lazy val for them to work.
