### PR TITLE
Implicit PortNumber in MixedFixtures

### DIFF
--- a/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
+++ b/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
@@ -64,6 +64,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
     implicit def implicitApp: FakeApplication = app
 
     /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
+
+    /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test.
      */
     override def apply() {
@@ -85,6 +91,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Make the passed in <code>FakeApplication</code> implicit.
      */
     implicit def implicitApp: FakeApplication = app
+
+    /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
 
     /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test, 
@@ -121,6 +133,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
     implicit def implicitApp: FakeApplication = app
 
     /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
+
+    /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test, 
      * and close the <code>FirefoxDriver</code> automatically after test execution.
      */
@@ -152,6 +170,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Make the passed in <code>FakeApplication</code> implicit.
      */
     implicit def implicitApp: FakeApplication = app
+
+    /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
 
     /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test, 
@@ -187,6 +211,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
     implicit def implicitApp: FakeApplication = app
 
     /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
+
+    /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test, 
      * and close the <code>ChromeDriver</code> automatically after test execution.
      */
@@ -219,6 +249,12 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Make the passed in <code>FakeApplication</code> implicit.
      */
     implicit def implicitApp: FakeApplication = app
+
+    /**
+     * Implicit <code>PortNumber</code> instance that wraps <code>port</code>. The value returned from <code>portNumber.value</code>
+     * will be same as the value of <code>port</code>.
+     */
+    implicit lazy val portNumber: PortNumber = PortNumber(port)
 
     /**
      * Override to run a <code>TestServer</code> using the passed in <code>port</code> before running the test, 

--- a/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
+++ b/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2001-2014 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.play
+
+import play.api.test._
+import org.scalatest.concurrent.ScalaFutures
+import play.api.mvc.Call
+
+class MixedFixturesWsScalaTestClientSpec extends MixedSpec with ScalaFutures {
+
+  val app: FakeApplication =
+    FakeApplication(
+      additionalConfiguration = Map("foo" -> "bar", "ehcacheplugin" -> "disabled"),
+      withRoutes = TestRoute
+    )
+
+  "WsScalaTestClient" when {
+
+    "used with MixedFixtures Server" must {
+
+      "have wsUrl works correctly" in new Server(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new Server(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+    "used with MixedFixtures HtmlUnit" must {
+
+      "have wsUrl works correctly" in new HtmlUnit(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new HtmlUnit(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+    "used with MixedFixtures Firefox" must {
+
+      "have wsUrl works correctly" in new Firefox(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new Firefox(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+    "used with MixedFixtures Safari" must {
+
+      "have wsUrl works correctly" in new Safari(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new Safari(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+    "used with MixedFixtures Chrome" must {
+
+      "have wsUrl works correctly" in new Chrome(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new Chrome(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+    "used with MixedFixtures InternetExplorer" must {
+
+      "have wsUrl works correctly" in new InternetExplorer(app) {
+        val futureResult = wsUrl("/testing").get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+      "have wsCall works correctly" in new InternetExplorer(app) {
+        val futureResult = wsCall(Call("get", "/testing")).get
+        val body = futureResult.futureValue.body
+        val expectedBody =
+          "<html>" +
+            "<head><title>Test Page</title></head>" +
+            "<body>" +
+            "<input type='button' name='b' value='Click Me' onclick='document.title=\"scalatest\"' />" +
+            "</body>" +
+            "</html>"
+        assert(body == expectedBody)
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/org/scalatestplus/play/MixedSpec.scala
+++ b/src/test/scala/org/scalatestplus/play/MixedSpec.scala
@@ -25,5 +25,5 @@ import concurrent.IntegrationPatience
  * Browser) in different tests.
 */
 abstract class MixedSpec extends fixture.WordSpec with MustMatchers with OptionValues with Inside with MixedFixtures with
-    Eventually with IntegrationPatience
+    Eventually with IntegrationPatience with WsScalaTestClient
 


### PR DESCRIPTION
-Added PortNumber implicit in Server, HtmlUnit, Firefox, Safari, Chrome, and InternetExplorer NoArgs in MixedFixtures
-Make MixedSpec to mixin WsScalaTestClient.
