### PR TITLE
Update version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,6 @@ ScalaTest + Play provides integration support between ScalaTest and Play Framewo
 
 To use it, please add the following dependency to your project's build.sbt/Build.scala file:
 
-  `libraryDependencies += "org.scalatestplus" %% "play" % "1.0.0" % "test"`
+  `libraryDependencies += "org.scalatestplus" %% "play" % "1.2.0" % "test"`
+
+Version 1.2.0 depends on scalatest 2.2, to use it with scalatest 2.1.x you should use scalatestplus-play 1.1.0.


### PR DESCRIPTION
Changes the README to show version 1.2.0, also mention that 1.1.0 should be used for scalatest 2.1