### PR TITLE
Lazy MixedFixtures

### DIFF
--- a/project/ScalaTestPlusPlayBuild.scala
+++ b/project/ScalaTestPlusPlayBuild.scala
@@ -19,7 +19,7 @@ import com.typesafe.sbt.SbtPgp._
 
 object ScalaTestPlusPlayBuild extends Build {
 
-  val releaseVersion = "1.4.0"
+  val releaseVersion = "1.4.1-M1"
   val projectTitle = "ScalaTest + Play" // for scaladoc source urls
 
   def envVar(name: String): Option[String] =

--- a/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
+++ b/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
@@ -292,11 +292,16 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
   /**
    * `NoArg` subclass that provides an `Application` fixture.
    */
-  abstract class App(val app: Application = FakeApplication()) extends NoArg {
+  abstract class App(appFun: => Application = FakeApplication()) extends NoArg {
     /**
      * Makes the passed-in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Runs the passed in `Application` before executing the test body, ensuring it is closed after the test body completes.
@@ -310,11 +315,16 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
   /**
    * `NoArg` subclass that provides a fixture composed of a `Application` and running `TestServer`.
    */
-  abstract class Server(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends NoArg {
+  abstract class Server(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends NoArg {
     /**
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -336,7 +346,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `HtmlUnitDriver`.
    */
-  abstract class HtmlUnit(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with HtmlUnitFactory {
+  abstract class HtmlUnit(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with HtmlUnitFactory {
     /**
      * A lazy implicit instance of `HtmlUnitDriver`. It will hold `UnavailableDriver` if `HtmlUnitDriver` 
      * is not available in the running machine.
@@ -347,6 +357,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -378,7 +393,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of a `Application`, running `TestServer`, and
    * Selenium `FirefoxDriver`.
    */
-  abstract class Firefox(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with FirefoxFactory {
+  abstract class Firefox(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with FirefoxFactory {
 
     /**
      * A lazy implicit instance of `FirefoxDriver`, it will hold `UnavailableDriver` if `FirefoxDriver` 
@@ -390,6 +405,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -421,7 +441,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `SafariDriver`.
    */
-  abstract class Safari(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with SafariFactory {
+  abstract class Safari(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with SafariFactory {
     /**
      * A lazy implicit instance of `SafariDriver`, it will hold `UnavailableDriver` if `SafariDriver` 
      * is not available in the running machine.
@@ -432,6 +452,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -463,7 +488,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `ChromeDriver`.
    */
-  abstract class Chrome(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with ChromeFactory {
+  abstract class Chrome(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with ChromeFactory {
     /**
      * A lazy implicit instance of `ChromeDriver`, it will hold `UnavailableDriver` if `ChromeDriver` 
      * is not available in the running machine.
@@ -474,6 +499,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -506,7 +536,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `InternetExplorerDriver`.
    */
-  abstract class InternetExplorer(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with InternetExplorerFactory {
+  abstract class InternetExplorer(appFun: => Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with InternetExplorerFactory {
     /**
      * A lazy implicit instance of `InternetExplorerDriver`, it will hold `UnavailableDriver` if `InternetExplorerDriver` 
      * is not available in the running machine.
@@ -517,6 +547,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`

--- a/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
+++ b/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
@@ -18,6 +18,7 @@ package org.scalatestplus.play
 import play.api.test._
 import org.scalatest._
 import play.api.{Play, Application}
+import play.api.mvc.Handler
 
 class MixedFixtureSpec extends MixedSpec {
 
@@ -34,6 +35,34 @@ class MixedFixtureSpec extends MixedSpec {
     "start the FakeApplication" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        "test 1" in new App(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+        "test 2" in new App(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+        "test 3" in new App(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      count mustBe 3
+    }
   }
   "The Server function" must {
     "provide a FakeApplication" in new Server(fakeApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
@@ -44,6 +73,34 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the FakeApplication" in new Server(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        "test 1" in new Server(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+        "test 2" in new Server(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+        "test 3" in new Server(new TestFakeApplication()) { t =>
+          assert(count == 1)
+        }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      count mustBe 3
     }
     import Helpers._
     "send 404 on a bad request" in new Server {
@@ -63,6 +120,32 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the FakeApplication" in new HtmlUnit(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new HtmlUnit(new TestFakeApplication()) { t => testRun = true }
+        "test 2" in new HtmlUnit(new TestFakeApplication()) { t => testRun = true }
+        "test 3" in new HtmlUnit(new TestFakeApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new HtmlUnit {
@@ -89,6 +172,32 @@ class MixedFixtureSpec extends MixedSpec {
     "start the FakeApplication" in new Firefox(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Firefox(new TestFakeApplication()) { t => testRun = true }
+        "test 2" in new Firefox(new TestFakeApplication()) { t => testRun = true }
+        "test 3" in new Firefox(new TestFakeApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
+    }
     import Helpers._
     "send 404 on a bad request" in new Firefox {
       import java.net._
@@ -113,6 +222,32 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the FakeApplication" in new Safari(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Safari(new TestFakeApplication()) { t => testRun = true }
+        "test 2" in new Safari(new TestFakeApplication()) { t => testRun = true }
+        "test 3" in new Safari(new TestFakeApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new Safari {
@@ -139,6 +274,32 @@ class MixedFixtureSpec extends MixedSpec {
     "start the FakeApplication" in new Chrome(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Chrome(new TestFakeApplication()) { t => testRun = true }
+        "test 2" in new Chrome(new TestFakeApplication()) { t => testRun = true }
+        "test 3" in new Chrome(new TestFakeApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
+    }
     import Helpers._
     "send 404 on a bad request" in new Chrome {
       import java.net._
@@ -163,6 +324,32 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the FakeApplication" in new InternetExplorer(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the FakeApplication lazily" in new App(fakeApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestFakeApplication(override val path: java.io.File = new java.io.File("."),
+                                override val classloader: ClassLoader = classOf[FakeApplication].getClassLoader,
+                                additionalPlugins: Seq[String] = Nil,
+                                withoutPlugins: Seq[String] = Nil,
+                                additionalConfiguration: Map[String, _ <: Any] = Map.empty,
+                                withGlobal: Option[play.api.GlobalSettings] = None,
+                                withRoutes: PartialFunction[(String, String), Handler] = PartialFunction.empty)
+        extends FakeApplication(path, classloader, additionalPlugins, withoutPlugins, additionalConfiguration, withGlobal, withRoutes) {
+        count = count + 1
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new InternetExplorer(new TestFakeApplication()) { t => testRun = true }
+        "test 2" in new InternetExplorer(new TestFakeApplication()) { t => testRun = true }
+        "test 3" in new InternetExplorer(new TestFakeApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new InternetExplorer {

--- a/src/test/scala/org/scalatestplus/play/SilentReporter.scala
+++ b/src/test/scala/org/scalatestplus/play/SilentReporter.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.play
+
+import org.scalatest._
+
+object SilentReporter extends Reporter {
+  def apply(event: events.Event) {}
+}


### PR DESCRIPTION
Changed App, Server, HtmlUnit, Firefox, Chrome, Safari and InternetExplorer in MixedFixtures to create Application instance lazily.  This helps to delay creation of Application instance from test registration to test execution.