### PR TITLE
Lazy MixedFixtures for Master

### DIFF
--- a/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
+++ b/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
@@ -16,6 +16,7 @@
 package org.scalatestplus.play
 
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import org.scalatest._
 import fixture._
@@ -259,11 +260,16 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
   /**
    * `NoArg` subclass that provides an `Application` fixture.
    */
-  abstract class App(val app: Application = FakeApplication()) extends NoArg {
+  abstract class App(appFun: => Application = (new GuiceApplicationBuilder()).build()) extends NoArg {
     /**
      * Makes the passed-in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Runs the passed in `Application` before executing the test body, ensuring it is closed after the test body completes.
@@ -277,11 +283,16 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
   /**
    * `NoArg` subclass that provides a fixture composed of a `Application` and running `TestServer`.
    */
-  abstract class Server(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends NoArg {
+  abstract class Server(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends NoArg {
     /**
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -303,7 +314,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `HtmlUnitDriver`.
    */
-  abstract class HtmlUnit(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with HtmlUnitFactory {
+  abstract class HtmlUnit(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with HtmlUnitFactory {
     /**
      * A lazy implicit instance of `HtmlUnitDriver`. It will hold `UnavailableDriver` if `HtmlUnitDriver` 
      * is not available in the running machine.
@@ -314,6 +325,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -345,7 +361,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of a `Application`, running `TestServer`, and
    * Selenium `FirefoxDriver`.
    */
-  abstract class Firefox(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with FirefoxFactory {
+  abstract class Firefox(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with FirefoxFactory {
 
     /**
      * A lazy implicit instance of `FirefoxDriver`, it will hold `UnavailableDriver` if `FirefoxDriver` 
@@ -357,6 +373,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -388,7 +409,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `SafariDriver`.
    */
-  abstract class Safari(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with SafariFactory {
+  abstract class Safari(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with SafariFactory {
     /**
      * A lazy implicit instance of `SafariDriver`, it will hold `UnavailableDriver` if `SafariDriver` 
      * is not available in the running machine.
@@ -399,6 +420,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -430,7 +456,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `ChromeDriver`.
    */
-  abstract class Chrome(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with ChromeFactory {
+  abstract class Chrome(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with ChromeFactory {
     /**
      * A lazy implicit instance of `ChromeDriver`, it will hold `UnavailableDriver` if `ChromeDriver` 
      * is not available in the running machine.
@@ -441,6 +467,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`
@@ -472,7 +503,7 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
    * `NoArg` subclass that provides a fixture composed of an `Application`, running `TestServer`, and
    * Selenium `InternetExplorerDriver`.
    */
-  abstract class InternetExplorer(val app: Application = FakeApplication(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with InternetExplorerFactory {
+  abstract class InternetExplorer(appFun: => Application = (new GuiceApplicationBuilder()).build(), val port: Int = Helpers.testServerPort) extends WebBrowser with NoArg with InternetExplorerFactory {
     /**
      * A lazy implicit instance of `InternetExplorerDriver`, it will hold `UnavailableDriver` if `InternetExplorerDriver` 
      * is not available in the running machine.
@@ -483,6 +514,11 @@ trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
      * Makes the passed in `Application` implicit.
      */
     implicit def implicitApp: Application = app
+
+    /**
+     * The lazy instance created from passed <code>appFun</code>
+     */
+    lazy val app = appFun
 
     /**
      * Implicit `PortNumber` instance that wraps `port`. The value returned from `portNumber.value`

--- a/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
@@ -15,10 +15,16 @@
  */
 package org.scalatestplus.play
 
+import akka.actor.ActorSystem
+import play.api.http.{HttpErrorHandler, HttpRequestHandler}
+import play.api.inject.Injector
 import play.api.test._
-import play.api.{Play, Application}
+import play.api._
 import play.api.inject.guice._
 import play.api.routing._
+import org.scalatest._
+
+import scala.concurrent.Future
 
 class MixedFixtureSpec extends MixedSpec {
 
@@ -36,6 +42,32 @@ class MixedFixtureSpec extends MixedSpec {
     "start the Application" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        "test 1" in new App(new TestApplication()) { t => }
+        "test 2" in new App(new TestApplication()) { t => }
+        "test 3" in new App(new TestApplication()) { t => }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      count mustBe 3
+    }
   }
   "The Server function" must {
     "provide a Application" in new Server(buildApp("foo" -> "bar", "ehcacheplugin" -> "disabled")) {
@@ -46,6 +78,32 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the Application" in new Server(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        "test 1" in new Server(new TestApplication()) { t => }
+        "test 2" in new Server(new TestApplication()) { t => }
+        "test 3" in new Server(new TestApplication()) { t => }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      count mustBe 3
     }
     import Helpers._
     "send 404 on a bad request" in new Server {
@@ -65,6 +123,36 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the Application" in new HtmlUnit(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new HtmlUnit(new TestApplication()) { t => testRun = true }
+        "test 2" in new HtmlUnit(new TestApplication()) { t => testRun = true }
+        "test 3" in new HtmlUnit(new TestApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new HtmlUnit {
@@ -91,6 +179,36 @@ class MixedFixtureSpec extends MixedSpec {
     "start the Application" in new Firefox(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Firefox(new TestApplication()) { t => testRun = true }
+        "test 2" in new Firefox(new TestApplication()) { t => testRun = true }
+        "test 3" in new Firefox(new TestApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
+    }
     import Helpers._
     "send 404 on a bad request" in new Firefox {
       import java.net._
@@ -115,6 +233,36 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the Application" in new Safari(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Safari(new TestApplication()) { t => testRun = true }
+        "test 2" in new Safari(new TestApplication()) { t => testRun = true }
+        "test 3" in new Safari(new TestApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new Safari {
@@ -141,6 +289,36 @@ class MixedFixtureSpec extends MixedSpec {
     "start the Application" in new Chrome(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
     }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new Chrome(new TestApplication()) { t => testRun = true }
+        "test 2" in new Chrome(new TestApplication()) { t => testRun = true }
+        "test 3" in new Chrome(new TestApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
+    }
     import Helpers._
     "send 404 on a bad request" in new Chrome {
       import java.net._
@@ -165,6 +343,36 @@ class MixedFixtureSpec extends MixedSpec {
     }
     "start the Application" in new InternetExplorer(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
       Play.maybeApplication mustBe Some(app)
+    }
+    "start the Application lazily" in new App(buildApp("foo" -> "bar",  "ehcacheplugin" -> "disabled")) {
+      var count = 0
+      class TestApplication extends Application {
+        count = count + 1
+        private val app: Application = (new GuiceApplicationBuilder()).build()
+        override def mode: Mode.Mode = app.mode
+        override def configuration: Configuration = app.configuration
+        override def actorSystem: ActorSystem = app.actorSystem
+        override def requestHandler: HttpRequestHandler = app.requestHandler
+        override def errorHandler: HttpErrorHandler = app.errorHandler
+        override def stop() = app.stop()
+        override def injector: Injector = app.injector
+        override def classloader = app.classloader
+        implicit override def materializer = app.materializer
+        override def path: java.io.File = app.path
+      }
+      class TestSpec extends fixture.WordSpec with MixedFixtures {
+        var testRun = false  // will be false if test is canceled due to driver not available on platform.
+        "test 1" in new InternetExplorer(new TestApplication()) { t => testRun = true }
+        "test 2" in new InternetExplorer(new TestApplication()) { t => testRun = true }
+        "test 3" in new InternetExplorer(new TestApplication()) { t => testRun = true }
+      }
+      val spec = new TestSpec
+      count mustBe 0
+      spec.run(None, Args(SilentReporter))
+      if (spec.testRun)
+        count mustBe 3
+      else
+        count mustBe 0  // when driver not available, not Application instance should be created at all.
     }
     import Helpers._
     "send 404 on a bad request" in new InternetExplorer {

--- a/module/src/test/scala/org/scalatestplus/play/SilentReporter.scala
+++ b/module/src/test/scala/org/scalatestplus/play/SilentReporter.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.play
+
+import org.scalatest._
+
+object SilentReporter extends Reporter {
+  def apply(event: events.Event) {}
+}


### PR DESCRIPTION
Changed App, Server, HtmlUnit, Firefox, Chrome, Safari and InternetExplorer in MixedFixtures to create Application instance lazily, this delays the creation of passed in Application from test registration to test execution.