### PR TITLE
Add option for taking WSClient to help with 2.5.x deprecation.

### DIFF
--- a/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
@@ -107,7 +107,7 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
         }
     }).build()
 
-    "run in a browser" in new HtmlUnit(app = applicationWithBrowser) {
+    "run in a browser" in new HtmlUnit(appFun = { applicationWithBrowser }) {
 
       // Check the home page
       go to "http://localhost:" + port
@@ -121,14 +121,16 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
     // #scalafunctionaltest-testwithbrowser
 
     // #scalafunctionaltest-testpaymentgateway
-    "test server logic" in new Server(app = applicationWithBrowser, port = 19001) { port =>
+    "test server logic" in new Server(appFun = { applicationWithBrowser }, port = 19001) { port =>
+      implicit val wsClient = app.injector.instanceOf[WSClient]
+
       val myPublicAddress =  s"localhost:$port"
       val testPaymentGatewayURL = s"http://$myPublicAddress"
       // The test payment gateway requires a callback to this server before it returns a result...
       val callbackURL = s"http://$myPublicAddress/callback"
 
       // await is from play.api.test.FutureAwaits
-      val response = await(WS.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
+      val response = await(wsClient.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
 
       response.status mustEqual OK
     }
@@ -142,8 +144,9 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
         }
     }).build()
 
-    "test WS logic" in new Server(app = appWithRoutes, port = 3333) {
-      await(WS.url("http://localhost:3333").get()).status mustEqual OK
+    "test WS logic" in new Server(appFun = appWithRoutes, port = 3333) {
+      val wsClient = app.injector.instanceOf[WSClient]
+      await(wsClient.url("http://localhost:3333").get()).status mustEqual OK
     }
     // #scalafunctionaltest-testws
   }

--- a/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/ExampleSpec.scala
@@ -25,12 +25,13 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite {
     }).build()
 
   "test server logic" in {
+    val wsClient = app.injector.instanceOf[WSClient]
     val myPublicAddress =  s"localhost:$port"
     val testPaymentGatewayURL = s"http://$myPublicAddress"
     // The test payment gateway requires a callback to this server before it returns a result...
     val callbackURL = s"http://$myPublicAddress/callback"
     // await is from play.api.test.FutureAwaits
-    val response = await(WS.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
+    val response = await(wsClient.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
 
     response.status mustBe (OK)
   }

--- a/docs/manual/working/scalaGuide/main/tests/code/oneserverpertest/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/oneserverpertest/ExampleSpec.scala
@@ -26,12 +26,13 @@ class ExampleSpec extends PlaySpec with OneServerPerTest {
 
   "The OneServerPerTest trait" must {
     "test server logic" in {
+      val wsClient = app.injector.instanceOf[WSClient]
       val myPublicAddress =  s"localhost:$port"
       val testPaymentGatewayURL = s"http://$myPublicAddress"
       // The test payment gateway requires a callback to this server before it returns a result...
       val callbackURL = s"http://$myPublicAddress/callback"
       // await is from play.api.test.FutureAwaits
-      val response = await(WS.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
+      val response = await(wsClient.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
 
       response.status mustBe (OK)
     }

--- a/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
+++ b/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
@@ -16,7 +16,7 @@
 package org.scalatestplus.play
 
 import play.api.Play.current
-import play.api.libs.ws.{WS, WSRequest}
+import play.api.libs.ws.{WS, WSClient, WSRequest}
 import play.api.mvc.Call
 
 /**
@@ -34,14 +34,20 @@ trait WsScalaTestClient {
    *
    * @param call the `Call` describing the request
    * @param portNumber the port number of the `TestServer`
+   * @param wsClient the implicit WSClient
    */
-  def wsCall(call: Call)(implicit portNumber: PortNumber): WSRequest = wsUrl(call.url)
+  def wsCall(call: Call)(implicit portNumber: PortNumber, wsClient: WSClient = WS.client): WSRequest = doCall(call.url, wsClient, portNumber)
 
   /**
    * Construct a WS request for the given relative URL.
    *
    * @param url the URL of the request
    * @param portNumber the port number of the `TestServer`
+   * @param wsClient the implicit WSClient
    */
-  def wsUrl(url: String)(implicit portNumber: PortNumber): WSRequest = WS.url("http://localhost:" + portNumber.value + url)
+  def wsUrl(url: String)(implicit portNumber: PortNumber, wsClient: WSClient = WS.client): WSRequest = doCall(url, wsClient, portNumber)
+
+  private def doCall(url: String, wsClient: WSClient, portNumber: PortNumber) = {
+    wsClient.url("http://localhost:" + portNumber.value + url)
+  }
 }


### PR DESCRIPTION
WS.client is deprecated, so let's make an implicit WSClient available.  

It's not possible to add two overloads with implicits because it's ambiguous, so the default is to use WS.client for the implicit argument.