### PR TITLE
Add JBrowserDriver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val `scalatestplus-play` = project
       "org.scalatest" %% "scalatest" % "2.2.6",
       "com.typesafe.play" %% "play-test" % PlayVersion,
       "org.seleniumhq.selenium" % "selenium-java" % "2.48.2",
+      "com.machinepublishers" % "jbrowserdriver" % "0.10.1",
       "com.typesafe.play" %% "play-ws" % PlayVersion,
       "com.typesafe.play" %% "play-cache" % PlayVersion % Test
     ),

--- a/module/src/main/resources/org/scalatestplus/play/ScalaTestPlusPlayBundle.properties
+++ b/module/src/main/resources/org/scalatestplus/play/ScalaTestPlusPlayBundle.properties
@@ -3,6 +3,7 @@ cantCreateFirefoxDriver=Was unable to create a Selenium FirefoxDriver on this pl
 cantCreateSafariDriver=Was unable to create a Selenium SafariDriver on this platform: {0}
 cantCreateInternetExplorerDriver=Was unable to create a Selenium InternetExplorerDriver on this platform: {0}
 cantCreateChromeDriver=Was unable to create a Selenium ChromeDriver on this platform: {0}
+cantCreateJBrowserDriver=Was unable to create a Selenium JBrowserDriver on this platform: {0}
 and={0} and {1}
 webDriverUsedFromUnsharedTest=This test attempted to use a WebDriver, but the test is not one of the tests that are executed (shared) with multiple browsers. Did you forget to place this test inside the sharedTests method?
 webDriverUninitialized=Attempted to use a WebDriver before it was initialized.

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
@@ -207,6 +207,7 @@ trait AllBrowsersPerSuite extends SuiteMixin with WebBrowser with Eventually wit
       SafariInfo,
       InternetExplorerInfo,
       ChromeInfo,
+      JBrowserDriverInfo,
       HtmlUnitInfo(true)
     )
 

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
@@ -208,6 +208,7 @@ trait AllBrowsersPerTest extends SuiteMixin with WebBrowser with Eventually with
       SafariInfo,
       InternetExplorerInfo,
       ChromeInfo,
+      JBrowserDriverInfo,
       HtmlUnitInfo(true)
     )
 

--- a/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
@@ -161,6 +161,30 @@ case object ChromeInfo extends BrowserInfo("[Chrome]", "org.scalatest.tags.Chrom
 }
 
 /**
+ * JBrowserDriver info, which encapsulates the browser name, `"[JBrowserDriver]"`; tag name, `org.scalatest.tags.JBrowserDriverBrowser`; and a factory method that produces a Selenium `ChromeDriver`.
+ *
+ * This object's superclass, `BrowserInfo`, is used by [[org.scalatestplus.play.AllBrowsersPerSuite AllBrowsersPerSuite]] and
+ * [[org.scalatestplus.play.AllBrowsersPerTest AllBrowsersPerTest]]: an `IndexedSeq[BrowserInfo]` is returned
+ * from the `browsers` field of these traits to specify the browsers to share between tests.
+ * When tests are registered, `AllBrowsersPerSuite` and `AllBrowsersPerTest` use the browser name to ensure the tests shared by multiple browsers
+ * have unique names (the name of each shared test is appended with a browser name). When the tests run, these traits
+ * use the `BrowserInfo`'s factory method to create `WebDriver`s as needed.
+ * The `AllBrowsersPerSuite` and `AllBrowsersPerTest` traits use the  tag name to automatically tag any tests that use
+ * a particular `WebDriver` with the appropriate tag so that tests can be dynamically filtered by the browser the use.
+ */
+case object JBrowserDriverInfo extends BrowserInfo("[JBrowserDriver]", "org.scalatest.tags.JBrowserDriverBrowser") {
+
+  /**
+   * Creates a new instance of a Selenium `JBrowserDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes
+   * the exception that indicates JBrowserDriver was not supported on the host platform and an appropriate
+   * error message.
+   *
+   * @return an new instance of a Selenium `JBrowserDriver`, or a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] if JBrowserDriver was not available on the host platform.
+   */
+  def createWebDriver(): WebDriver = JBrowserDriverFactory.createWebDriver()
+}
+
+/**
  * `HtmlUnit` browser info, which encapsulates the browser name, `"[HtmlUnit]"`; tag name, `org.scalatest.tags.HtmlUnitBrowser`; and a factory method that produces a Selenium `HtmlUnitDriver`.
  *
  * This object's superclass, `BrowserInfo`, is used by [[org.scalatestplus.play.AllBrowsersPerSuite AllBrowsersPerSuite]] and

--- a/module/src/main/scala/org/scalatestplus/play/JBrowserDriverFactory.scala
+++ b/module/src/main/scala/org/scalatestplus/play/JBrowserDriverFactory.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Lightbend.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.play
+
+import org.openqa.selenium.WebDriver
+import org.scalatestplus.play.BrowserFactory.UnavailableDriver
+
+/**
+ * Factory whose `createWebDriver` method will either return a new Selenium `JBrowserDriverFactory`, or
+ * [[org.scalatestplus.play.BrowserFactory.UnavailableDriver UnavailableDriver]], if Chrome is not available on the host platform.
+ *
+ * Traits [[org.scalatestplus.play.OneBrowserPerSuite OneBrowserPerSuite]] and
+ * [[org.scalatestplus.play.OneBrowserPerTest OneBrowserPerTest]] extend `BrowserFactory` and therefore require
+ * you to fill in the `createWebDriver` method, usually by mixing in one of the `BrowserFactory` subtraits such as
+ * `JBrowserDriverFactory`.
+ */
+trait JBrowserDriverFactory extends BrowserFactory {
+
+  /**
+   * Creates a new instance of a Selenium `JBrowserDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes
+   * the exception that indicated the driver was not supported on the host platform and an appropriate
+   * error message.
+   *
+   * @return an new instance of a Selenium `JBrowserDriver`, or a `BrowserFactory.UnavailableDriver` if it is not
+   * available on the host platform.
+   */
+  def createWebDriver(): WebDriver =
+    try {
+      new com.machinepublishers.jbrowserdriver.JBrowserDriver()
+    }
+    catch {
+      case ex: Throwable => UnavailableDriver(Some(ex), Resources("cantCreateJBrowserDriver", ex.getMessage))
+    }
+}
+
+
+object JBrowserDriverFactory extends JBrowserDriverFactory


### PR DESCRIPTION
Adds a JBrowserDriver alongside HtmlUnit.

The motivation behind adding this is that HtmlUnit does not work with jQuery 2.2.x 
