### PR TITLE
Correct/update scalatest docs to Play 2.5.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,13 @@
+Copyright 2001-2016 Artima, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-scalatestplus-play
-==================
+# ScalaTest _Plus_ Play
 
 ScalaTest + Play provides integration support between ScalaTest and Play Framework (http://www.playframework.com).
 
-To use it, please add the following dependency to your project's build.sbt/Build.scala file:
+To use it, please add the following dependency to your project's `build.sbt` or `project/Build.scala` file:
 
-  `libraryDependencies += "org.scalatestplus" %% "play" % "1.0.0" % "test"`
+```scala
+"org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
+```
+
+## Docs:
+
+See http://www.scalatest.org/plus/play

--- a/docs/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithScalaTest.md
+++ b/docs/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithScalaTest.md
@@ -5,26 +5,19 @@ Play provides a number of classes and convenience methods that assist with funct
 
 You can access all of Play's built-in test support and _ScalaTest + Play_ with the following imports:
 
-```scala
-import org.scalatest._
-import play.api.test._
-import play.api.test.Helpers._
-import org.scalatestplus.play._
-```
+@[scalafunctionaltest-imports](code/ScalaFunctionalTestSpec.scala)
 
-## FakeApplication
+## Creating `Application` instances for testing
 
-Play frequently requires a running [`Application`](api/scala/play/api/Application.html) as context: it is usually provided from [`play.api.Play.current`](api/scala/play/api/Play$.html).
+Play frequently requires a running [`Application`](api/scala/play/api/Application.html) as context. If you're using the default Guice dependency injection, you can use the [`GuiceApplicationBuilder`](api/scala/play/api/inject/guice/GuiceApplicationBuilder.html) class which can be configured with different configuration, routes, or even additional modules.
 
-To provide an environment for tests, Play provides a [`FakeApplication`](api/scala/play/api/test/FakeApplication.html) class which can be configured with a different `Global` object, additional configuration, or even additional plugins.
+@[scalafunctionaltest-application](code/ScalaFunctionalTestSpec.scala)
 
-@[scalafunctionaltest-fakeApplication](code/ScalaFunctionalTestSpec.scala)
-
-If all or most tests in your test class need a `FakeApplication`, and they can all share the same `FakeApplication`, mix in trait [`OneAppPerSuite`](api/scala/org/scalatestplus/play/OneAppPerSuite.html). You can access the `FakeApplication` from the `app` field. If you need to customize the `FakeApplication`, override `app` as shown in this example:
+If all or most tests in your test class need a `Application`, and they can all share the same instance of `Application`, mix in trait [`OneAppPerSuite`](api/scala/org/scalatestplus/play/OneAppPerSuite.html). You can access the `Application` from the `app` field. If you need to customize the `Application`, override `app` as shown in this example:
 
 @[scalafunctionaltest-oneapppersuite](code/oneapppersuite/ExampleSpec.scala)
 
-If you need each test to get its own `FakeApplication`, instead of sharing the same one, use `OneAppPerTest` instead:
+If you need each test to get its own `Application`, instead of sharing the same one, use `OneAppPerTest` instead:
 
 @[scalafunctionaltest-oneapppertest](code/oneapppertest/ExampleSpec.scala)
 
@@ -32,23 +25,23 @@ The reason _ScalaTest + Play_ provides both `OneAppPerSuite` and `OneAppPerTest`
 
 ## Testing with a server
 
-Sometimes you want to test with the real HTTP stack. If all tests in your test class can reuse the same server instance, you can mix in [`OneServerPerSuite`](api/scala/org/scalatestplus/play/OneServerPerSuite.html) (which will also provide a new `FakeApplication` for the suite):
+Sometimes you want to test with the real HTTP stack. If all tests in your test class can reuse the same server instance, you can mix in [`OneServerPerSuite`](api/scala/org/scalatestplus/play/OneServerPerSuite.html) (which will also provide a new `Application` for the suite):
 
 @[scalafunctionaltest-oneserverpersuite](code/oneserverpersuite/ExampleSpec.scala)
 
-If all tests in your test class require separate server instance, use [`OneServerPerTest`](api/scala/org/scalatestplus/play/OneServerPerTest.html) instead (which will also provide a new `FakeApplication` for the suite):
+If all tests in your test class require separate server instances, use [`OneServerPerTest`](api/scala/org/scalatestplus/play/OneServerPerTest.html) instead (which will also provide a new `Application` for the suite):
 
 @[scalafunctionaltest-oneserverpertest](code/oneserverpertest/ExampleSpec.scala)
 
 The `OneServerPerSuite` and `OneServerPerTest` traits provide the port number on which the server is running as the `port` field.  By default this is 19001, however you can change this either overriding `port` or by setting the system property `testserver.port`.  This can be useful for integrating with continuous integration servers, so that ports can be dynamically reserved for each build.
 
-You can also customize the [`FakeApplication`](api/scala/play/api/test/FakeApplication.html) by overriding `app`, as demonstrated in the previous examples.
+You can also customize the [`Application`](api/scala/play/api/test/FakeApplication.html) by overriding `app`, as demonstrated in the previous examples.
 
 Lastly, if allowing multiple test classes to share the same server will give you better performance than either the `OneServerPerSuite` or `OneServerPerTest` approaches, you can define a master suite that mixes in [`OneServerPerSuite`](api/scala/org/scalatestplus/play/OneServerPerSuite.html) and nested suites that mix in [`ConfiguredServer`](api/scala/org/scalatestplus/play/ConfiguredServer.html), as shown in the example in the [documentation for `ConfiguredServer`](api/scala/org/scalatestplus/play/ConfiguredServer.html).
 
 ## Testing with a web browser
 
-The _ScalaTest + Play_ library builds on ScalaTest's [Selenium DSL](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.selenium.WebBrowser) to make it easy to test your Play applications from web browsers.
+The _ScalaTest + Play_ library builds on ScalaTest's [Selenium DSL](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.selenium.WebBrowser) to make it easy to test your Play applications from web browsers.
 
 To run all tests in your test class using a same browser instance, mix [`OneBrowserPerSuite`](api/scala/org/scalatestplus/play/OneBrowserPerSuite.html) into your test class. You'll also need to mix in a [`BrowserFactory`](api/scala/org/scalatestplus/play/BrowserFactory.html) trait that will provide a Selenium web driver: one of [`ChromeFactory`](api/scala/org/scalatestplus/play/ChromeFactory.html), [`FirefoxFactory`](api/scala/org/scalatestplus/play/FirefoxFactory.html), [`HtmlUnitFactory`](api/scala/org/scalatestplus/play/HtmlUnitFactory.html), [`InternetExplorerFactory`](api/scala/org/scalatestplus/play/InternetExplorerFactory.html), [`SafariFactory`](api/scala/org/scalatestplus/play/SafariFactory.html).
 
@@ -66,11 +59,13 @@ If you need multiple test classes to share the same browser instance, mix [`OneB
 
 ## Running the same tests in multiple browsers
 
-If you want to run tests in multiple web browsers, to ensure your application works correctly in all the browsers you support, you can use traits [`AllBrowsersPerSuite`](api/scala/org/scalatestplus/play/AllBrowsersPerSuite.html) or [`AllBrowsersPerTest`](api/scala/org/scalatestplus/play/AllBrowsersPerTest.html). Both of these traits declare a `browsers` field of type `IndexedSeq[BrowserInfo]` and an abstract `sharedTests` method that takes a `BrowserInfo`. The `browsers` field indicates which browsers you want your tests to run in. The default is Chrome, Firefox, Internet Explorer, `HtmlUnit`, and Safari. You can override `browsers` if the default doesn't fit your needs. You place tests you want run in multiple browsers in the `sharedTests` method, placing the name of the browser at the end of each test name. (The browser name is available from the `BrowserInfo` passed into `sharedTests`.) Here's an example that uses `AllBrowsersPerSuite`:
+If you want to run tests in multiple web browsers, to ensure your application works correctly in all the browsers you support, you can use traits [`AllBrowsersPerSuite`](api/scala/org/scalatestplus/play/AllBrowsersPerSuite.html) or [`AllBrowsersPerTest`](api/scala/org/scalatestplus/play/AllBrowsersPerTest.html). Both of these traits declare a `browsers` field of type `IndexedSeq[BrowserInfo]` and an abstract `sharedTests` method that takes a `BrowserInfo`. The `browsers` field indicates which browsers you want your tests to run in. The default is Chrome, Firefox, Internet Explorer, `HtmlUnit`, and Safari. You can override `browsers` if the default does not fit your needs. You place tests you want to run in multiple browsers in the `sharedTests` method, placing the name of the browser at the end of each test name. (The browser name is available from the `BrowserInfo` passed into `sharedTests`.) Here is an example that uses `AllBrowsersPerSuite`:
 
 @[scalafunctionaltest-allbrowserspersuite](code/allbrowserspersuite/ExampleSpec.scala)
 
-All tests declared by `sharedTests` will be run with all browsers mentioned in the `browsers` field, so long as they are available on the host system. Tests for any browser that is not available on the host system will be canceled automatically. Note that you need to append the `browser.name` manually to the test name to ensure each test in the suite has a unique name (which is required by ScalaTest). If you leave that off, you'll get a duplicate-test-name error when you run your tests.
+All tests declared by `sharedTests` will be run with all browsers mentioned in the `browsers` field, so long as they are available on the host system. Tests for any browser that is not available on the host system will be canceled automatically.
+
+> **Note**: You need to append the `browser.name` manually to the test name to ensure each test in the suite has a unique name (which is required by ScalaTest). If you leave that off, you'll get a duplicate-test-name error when you run your tests.
 
 [`AllBrowsersPerSuite`](api/scala/org/scalatestplus/play/AllBrowsersPerSuite.html) will create a single instance of each type of browser and use that for all the tests declared in `sharedTests`. If you want each test to have its own, brand new browser instance, use [`AllBrowsersPerTest`](api/scala/org/scalatestplus/play/AllBrowsersPerTest.html) instead:
 
@@ -84,7 +79,7 @@ The previous test class will only attempt to run the shared tests with Firefox a
 
 ## PlaySpec
 
-`PlaySpec` provides a convenience "super Suite" ScalaTest base class for Play tests, You get `WordSpec`, `MustMatchers`, `OptionValues`, and `WsScalaTestClient` automatically by extending `PlaySpec`:
+[`PlaySpec`](api/scala/org/scalatestplus/play/PlaySpec.html) provides a convenience "super Suite" ScalaTest base class for Play tests. You get `WordSpec`, `MustMatchers`, `OptionValues`, and `WsScalaTestClient` automatically by extending `PlaySpec`:
 
 @[scalafunctionaltest-playspec](code/playspec/ExampleSpec.scala)
 
@@ -94,7 +89,7 @@ You can mix any of the previously mentioned traits into `PlaySpec`.
 
 In all the test classes shown in previous examples, all or most tests in the test class required the same fixtures. While this is common, it is not always the case. If different tests in the same test class need different fixtures, mix in trait [`MixedFixtures`](api/scala/org/scalatestplus/play/MixedFixtures.html). Then give each individual test the fixture it needs using one of these no-arg functions: [App](api/scala/org/scalatestplus/play/MixedFixtures$App.html), [Server](api/scala/org/scalatestplus/play/MixedFixtures$Server.html), [Chrome](api/scala/org/scalatestplus/play/MixedFixtures$Chrome.html), [Firefox](api/scala/org/scalatestplus/play/MixedFixtures$Firefox.html), [HtmlUnit](api/scala/org/scalatestplus/play/MixedFixtures$HtmlUnit.html), [InternetExplorer](api/scala/org/scalatestplus/play/MixedFixtures$InternetExplorer.html), or [Safari](api/scala/org/scalatestplus/play/MixedFixtures$Safari.html).
 
-You cannot mix [`MixedFixtures`](api/scala/org/scalatestplus/play/MixedFixtures.html) into [`PlaySpec`](api/scala/org/scalatestplus/play/PlaySpec.html) because `MixedFixtures` requires a ScalaTest [`fixture.Suite`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.fixture.Suite) and `PlaySpec` is just a regular [`Suite`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.Suite). If you want a convenient base class for mixed fixtures, extend [`MixedPlaySpec`](api/scala/org/scalatestplus/play/MixedPlaySpec.html) instead. Here's an example:
+You cannot mix [`MixedFixtures`](api/scala/org/scalatestplus/play/MixedFixtures.html) into [`PlaySpec`](api/scala/org/scalatestplus/play/PlaySpec.html) because `MixedFixtures` requires a ScalaTest [`fixture.Suite`](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.fixture.Suite) and `PlaySpec` is just a regular [`Suite`](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.Suite). If you want a convenient base class for mixed fixtures, extend [`MixedPlaySpec`](api/scala/org/scalatestplus/play/MixedPlaySpec.html) instead. Here's an example:
 
 @[scalafunctionaltest-mixedfixtures](code/mixedfixtures/ExampleSpec.scala)
 
@@ -109,8 +104,6 @@ Since a template is a standard Scala function, you can execute it from your test
 You can call any `Action` code by providing a [`FakeRequest`](api/scala/play/api/test/FakeRequest.html):
 
 @[scalatest-examplecontrollerspec](code/ExampleControllerSpec.scala)
-
-Technically, you don't need [`WithApplication`](api/scala/play/api/test/WithApplication.html) here, although it wouldn't hurt anything to have it.
 
 ## Testing the router
 

--- a/docs/manual/working/scalaGuide/main/tests/ScalaTestingWithScalaTest.md
+++ b/docs/manual/working/scalaGuide/main/tests/ScalaTestingWithScalaTest.md
@@ -1,11 +1,11 @@
 <!--- Copyright (C) 2009-2016 Typesafe Inc. <http://www.typesafe.com> -->
 # Testing your application with ScalaTest
 
-Writing tests for your application can be an involved process. Play provides helpers and application stubs, and ScalaTest provides an integration library, [ScalaTest + Play](http://scalatest.org/plus/play), to make testing your application as easy as possible.
+Writing tests for your application can be an involved process. Play provides helpers and application stubs, and ScalaTest provides an integration library, _ScalaTest + Play_, to make testing your application as easy as possible.
 
 ## Overview
 
-The location for tests is in the "test" folder.  <!-- There are two sample test files created in the test folder which can be used as templates. -->
+The location for tests is in the "test" folder. <!-- There are two sample test files created in the test folder which can be used as templates. -->
 
 You can run tests from the Play console.
 
@@ -15,7 +15,7 @@ You can run tests from the Play console.
 * To run tests continually, run a command with a tilde in front, i.e. `~test-quick`.
 * To access test helpers such as `FakeRequest` in console, run `test:console`.
 
-Testing in Play is based on SBT, and a full description is available in the [testing SBT](http://www.scala-sbt.org/0.13.0/docs/Detailed-Topics/Testing) chapter.
+Testing in Play is based on SBT, and a full description is available in the [testing SBT](http://www.scala-sbt.org/0.13/docs/Testing.html) chapter.
 
 ## Using ScalaTest + Play
 
@@ -23,8 +23,7 @@ To use _ScalaTest + Play_, you'll need to add it to your build, by changing `bui
 
 ```scala
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "org.scalatestplus" %% "play" % "1.2.0" % "test",
+  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.0" % "test"
 )
 ```
 
@@ -40,7 +39,7 @@ You can run your tests with Play itself, or in IntelliJ IDEA (using the [Scala p
 
 ### Matchers
 
-`PlaySpec` mixes in ScalaTest's [`MustMatchers`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.MustMatchers), so you can write assertions using ScalaTest's matchers DSL:
+`PlaySpec` mixes in ScalaTest's [`MustMatchers`](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.MustMatchers), so you can write assertions using ScalaTest's matchers DSL:
 
 ```scala
 import play.api.test.Helpers._
@@ -48,13 +47,13 @@ import play.api.test.Helpers._
 "Hello world" must endWith ("world")
 ```
 
-For more information, see the documentation for [`MustMatchers`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.MustMatchers).
+For more information, see the documentation for [`MustMatchers`](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.MustMatchers).
 
 ### Mockito
 
 You can use mocks to isolate unit tests against external dependencies.  For example, if your class depends on an external `DataService` class, you can feed appropriate data to your class without instantiating a `DataService` object.
 
-ScalaTest provides integration with [Mockito](https://github.com/mockito/mockito) via its [`MockitoSugar`](http://doc.scalatest.org/2.1.5/index.html#org.scalatest.mock.MockitoSugar) trait.
+ScalaTest provides integration with [Mockito](https://github.com/mockito/mockito) via its [`MockitoSugar`](http://doc.scalatest.org/2.2.6/index.html#org.scalatest.mock.MockitoSugar) trait.
 
 To use Mockito, mix `MockitoSugar` into your test class and then use the Mockito library to mock dependencies:
 
@@ -98,7 +97,7 @@ class AnormUserRepository extends UserRepository {
 }
 ```
 
-and then access them through services:
+And then access them through services:
 
 @[scalatest-userservice](code/services/UserService.scala)
 
@@ -108,17 +107,17 @@ In this way, the `isAdmin` method can be tested by mocking out the `UserReposito
 
 ## Unit Testing Controllers
 
-When defining controllers as objects, they can be trickier to unit test. In Play this can be alleviated by [[dependency injection|ScalaDependencyInjection]]. Another way to finesse unit testing with a controller declared as a object is to use a trait with an [explicitly typed self reference](http://www.naildrivin5.com/scalatour/wiki_pages/ExplcitlyTypedSelfReferences) to the controller:
+Since your controllers are just regular classes, you can easily unit test them using Play helpers. If your controllers depends on another classes, using [[dependency injection|ScalaDependencyInjection]] will enable you to mock these dependencies. Per instance, given the following controller:
 
 @[scalatest-examplecontroller](code/ExampleControllerSpec.scala)
 
-and then test the trait:
+You can test it like:
 
 @[scalatest-examplecontrollerspec](code/ExampleControllerSpec.scala)
 
 ## Unit Testing EssentialAction
 
-Testing [`Action`](api/scala/play/api/mvc/Action.html) or [`Filter`](api/scala/play/api/mvc/Filter.html) can require to test an an [`EssentialAction`](api/scala/play/api/mvc/EssentialAction.html) ([[more information about what an EssentialAction is|ScalaEssentialAction]])
+Testing [`Action`](api/scala/play/api/mvc/Action.html) or [`Filter`](api/scala/play/api/mvc/Filter.html) can require testing an [`EssentialAction`](api/scala/play/api/mvc/EssentialAction.html) ([[more information about what an EssentialAction is|ScalaEssentialAction]])
 
 For this, the test [`Helpers.call`](api/scala/play/api/test/Helpers$.html#call) can be used like that:
 

--- a/docs/manual/working/scalaGuide/main/tests/code/ExampleControllerSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ExampleControllerSpec.scala
@@ -6,7 +6,6 @@ package scalaguide.tests.scalatest
 // #scalatest-examplecontrollerspec
 import scala.concurrent.Future
 
-import org.scalatest._
 import org.scalatestplus.play._
 
 import play.api.mvc._
@@ -15,11 +14,9 @@ import play.api.test.Helpers._
 
 class ExampleControllerSpec extends PlaySpec with Results {
 
-  class TestController() extends Controller with ExampleController
-
   "Example Page#index" should {
     "should be valid" in {
-      val controller = new TestController()
+      val controller = new ExampleController()
       val result: Future[Result] = controller.index().apply(FakeRequest())
       val bodyText: String = contentAsString(result)
       bodyText mustBe "ok"
@@ -29,13 +26,9 @@ class ExampleControllerSpec extends PlaySpec with Results {
 // #scalatest-examplecontrollerspec
 
 // #scalatest-examplecontroller
-trait ExampleController {
-  this: Controller =>
-
+class ExampleController extends Controller {
   def index() = Action {
     Ok("ok")
   }
 }
-
-object ExampleController extends Controller with ExampleController
 // #scalatest-examplecontroller

--- a/docs/manual/working/scalaGuide/main/tests/code/ExampleEssentialActionSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ExampleEssentialActionSpec.scala
@@ -3,7 +3,6 @@
  */
 package scalaguide.tests.scalatest
 
-import org.scalatest._
 import org.scalatestplus.play._
 
 import play.api.mvc._

--- a/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
@@ -3,13 +3,18 @@
  */
 package scalaguide.tests.scalatest
 
+// #scalafunctionaltest-imports
 import org.scalatest._
 import org.scalatestplus.play._
 
-import play.api.mvc._
-import play.api.test.FakeRequest
+import play.api.test._
 import play.api.test.Helpers.{GET => GET_REQUEST, _}
-import play.api.{GlobalSettings, Application}
+// #scalafunctionaltest-imports
+
+import play.api.mvc._
+
+import play.api.test.Helpers.{GET => GET_REQUEST, _}
+import play.api.Application
 import play.api.libs.ws._
 import play.api.inject.guice._
 import play.api.routing._
@@ -17,9 +22,6 @@ import play.api.routing.sird._
 
 abstract class MixedPlaySpec extends fixture.WordSpec with MustMatchers with OptionValues with MixedFixtures
 
-/**
- *
- */
 class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
 
   // lie and make this look like a DB model.
@@ -31,13 +33,13 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
 
   "Scala Functional Test" should {
 
-    // #scalafunctionaltest-fakeApplication
-    val applicationWithGlobal = new GuiceApplicationBuilder().global(new GlobalSettings() {
-      override def onStart(app: Application) { println("Hello world!") }
-    }).build()
-    // #scalafunctionaltest-fakeApplication
+    // #scalafunctionaltest-application
+    val application: Application = new GuiceApplicationBuilder()
+      .configure("some.configuration" -> "value")
+      .build()
+    // #scalafunctionaltest-application
 
-    val application = new GuiceApplicationBuilder().additionalRouter(Router.from {
+    val applicationWithRouter = new GuiceApplicationBuilder().router(Router.from {
       case GET(p"/Bob") =>
         Action {
           Ok("Hello Bob") as "text/html; charset=utf-8"
@@ -46,8 +48,8 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
 
 
     // #scalafunctionaltest-respondtoroute
-    "respond to the index Action" in new App(application) {
-      val Some(result) = route(FakeRequest(GET_REQUEST, "/Bob"))
+    "respond to the index Action" in new App(applicationWithRouter) {
+      val Some(result) = route(app, FakeRequest(GET_REQUEST, "/Bob"))
 
       status(result) mustEqual OK
       contentType(result) mustEqual Some("text/html")
@@ -79,7 +81,7 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
 
 
     // #scalafunctionaltest-testwithbrowser
-    def applicationWithBrowser = new GuiceApplicationBuilder().additionalRouter(Router.from {
+    def applicationWithBrowser = new GuiceApplicationBuilder().router(Router.from {
       case GET(p"/") =>
         Action {
           Ok(
@@ -137,7 +139,7 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
     // #scalafunctionaltest-testpaymentgateway
 
     // #scalafunctionaltest-testws
-    val appWithRoutes = new GuiceApplicationBuilder().additionalRouter(Router.from{
+    val appWithRoutes = new GuiceApplicationBuilder().router(Router.from{
       case GET(p"/") =>
         Action {
           Ok("ok")

--- a/docs/manual/working/scalaGuide/main/tests/code/StackSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/StackSpec.scala
@@ -4,21 +4,22 @@
 package scalaguide.tests.scalatest
 
 // #scalatest-stackspec
-import collection.mutable.Stack
 import org.scalatestplus.play._
+
+import scala.collection.mutable
 
 class StackSpec extends PlaySpec {
 
   "A Stack" must {
     "pop values in last-in-first-out order" in {
-      val stack = new Stack[Int]
+      val stack = new mutable.Stack[Int]
       stack.push(1)
       stack.push(2)
       stack.pop() mustBe 2
       stack.pop() mustBe 1
     }
     "throw NoSuchElementException if an empty stack is popped" in {
-      val emptyStack = new Stack[Int]
+      val emptyStack = new mutable.Stack[Int]
       a [NoSuchElementException] must be thrownBy {
         emptyStack.pop()
       }

--- a/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleOverrideBrowsersSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleOverrideBrowsersSpec.scala
@@ -23,7 +23,7 @@ class ExampleOverrideBrowsersSpec extends PlaySpec with OneServerPerSuite with A
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(

--- a/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleSpec.scala
@@ -16,7 +16,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with AllBrowsersPerSui
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(
@@ -33,7 +33,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with AllBrowsersPerSui
   def sharedTests(browser: BrowserInfo) = {
     "The AllBrowsersPerSuite trait" must {
       "provide a web driver " + browser.name in {
-        go to (s"http://localhost:$port/testing")
+        go to s"http://localhost:$port/testing"
         pageTitle mustBe "Test Page"
         click on find(name("b")).value
         eventually { pageTitle mustBe "scalatest" }

--- a/docs/manual/working/scalaGuide/main/tests/code/allbrowserspertest/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/allbrowserspertest/ExampleSpec.scala
@@ -16,7 +16,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with AllBrowsersPerTes
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(

--- a/docs/manual/working/scalaGuide/main/tests/code/mixedfixtures/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/mixedfixtures/ExampleSpec.scala
@@ -17,7 +17,7 @@ class ExampleSpec extends MixedPlaySpec {
 
   // Some helper methods
   def buildApp[A](elems: (String, String)*) =
-    new GuiceApplicationBuilder().configure(Map(elems:_*)).additionalRouter(Router.from {
+    new GuiceApplicationBuilder().configure(Map(elems:_*)).router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(
@@ -98,7 +98,7 @@ class ExampleSpec extends MixedPlaySpec {
   // If a test needs an Application, running TestServer, and Selenium
   // Firefox driver use "new Firefox":
   "The Firefox function" must {
-    "provide an pplication" in new Firefox(buildApp("ehcacheplugin" -> "disabled")) {
+    "provide an application" in new Firefox(buildApp("ehcacheplugin" -> "disabled")) {
       app.configuration.getString("ehcacheplugin") mustBe Some("disabled")
     }
     "make the Application available implicitly" in new Firefox(buildApp("ehcacheplugin" -> "disabled")) {

--- a/docs/manual/working/scalaGuide/main/tests/code/onebrowserpersuite/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/onebrowserpersuite/ExampleSpec.scala
@@ -3,7 +3,6 @@
  */
 package scalaguide.tests.scalatest.onebrowserpersuite
 
-import play.api.test._
 import org.scalatestplus.play._
 import play.api.mvc._
 import play.api.inject.guice._
@@ -17,7 +16,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with OneBrowserPerSuit
   // Override app if you need a Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(
@@ -33,7 +32,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with OneBrowserPerSuit
 
   "The OneBrowserPerTest trait" must {
     "provide a web driver" in {
-      go to (s"http://localhost:$port/testing")
+      go to s"http://localhost:$port/testing"
       pageTitle mustBe "Test Page"
       click on find(name("b")).value
       eventually { pageTitle mustBe "scalatest" }

--- a/docs/manual/working/scalaGuide/main/tests/code/onebrowserpertest/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/onebrowserpertest/ExampleSpec.scala
@@ -17,7 +17,7 @@ class ExampleSpec extends PlaySpec with OneServerPerTest with OneBrowserPerTest 
   // Override newAppForTest if you need a Application with other than
   // default parameters.
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(

--- a/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/ExampleSpec.scala
@@ -3,7 +3,6 @@
  */
 package scalaguide.tests.scalatest.oneserverpersuite
 
-import play.api.test._
 import org.scalatestplus.play._
 import play.api.test.Helpers.{GET => GET_REQUEST, _}
 import play.api.libs.ws._
@@ -20,7 +19,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite {
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/") => Action { Ok("ok") }
     }).build()
 
@@ -33,7 +32,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite {
     // await is from play.api.test.FutureAwaits
     val response = await(wsClient.url(testPaymentGatewayURL).withQueryString("callbackURL" -> callbackURL).get())
 
-    response.status mustBe (OK)
+    response.status mustBe OK
   }
 }
 // #scalafunctionaltest-oneserverpersuite

--- a/docs/manual/working/scalaGuide/main/tests/code/oneserverpertest/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/oneserverpertest/ExampleSpec.scala
@@ -20,7 +20,7 @@ class ExampleSpec extends PlaySpec with OneServerPerTest {
   // Override newAppForTest if you need an Application with other than
   // default parameters.
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/") => Action { Ok("ok") }
     }).build()
 

--- a/docs/manual/working/scalaGuide/main/tests/code/playspec/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/playspec/ExampleSpec.scala
@@ -18,7 +18,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with ScalaFutures with
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].additionalRouter(Router.from {
+    new GuiceApplicationBuilder().disable[EhCacheModule].router(Router.from {
       case GET(p"/testing") =>
         Action(
           Results.Ok(

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
@@ -103,8 +103,11 @@ import org.openqa.selenium.chrome.ChromeDriver
  *
  *   // Override app if you need an Application with other than
  *   // default parameters.
- *   implicit override lazy val app =
- *     new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").additionalRouter(Router.from(TestRoute)).build()
+ *   implicit override lazy val app = new GuiceApplicationBuilder()
+ *     .disable[EhCacheModule]
+ *     .configure("foo" -> "bar")
+ *     .router(Router.from(TestRoute))
+ *     .build()
  *
  *   // Place tests you want run in different browsers in the `sharedTests` method:
  *   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
@@ -104,8 +104,11 @@ import org.openqa.selenium.chrome.ChromeDriver
  * class ExampleSpec extends PlaySpec with OneServerPerTest with AllBrowsersPerTest {
  *
  *   // Override newAppForTest if you need a Application with other than non-default parameters.
- *   override def newAppForTest(testData: TestData): Application =
- *      new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").additionalRouter(Router.from(TestRoute)).build()
+ *   override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder()
+ *     .disable[EhCacheModule]
+ *     .configure("foo" -> "bar")
+ *     .router(Router.from(TestRoute))
+ *     .build()
  *
  *   // Place tests you want run in different browsers in the `sharedTests` method:
  *   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/main/scala/org/scalatestplus/play/BrowserFactory.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BrowserFactory.scala
@@ -45,7 +45,7 @@ import org.openqa.selenium._
 
 /**
  * Companion object to trait `BrowserFactory` that holds a `UnavailableDriver` object that implements 
- * the Selenium `WebDriver` interface by throwing `UnuspportedOperationException`. This is
+ * the Selenium `WebDriver` interface by throwing `UnsupportedOperationException`. This is
  * used as a placeholder when a driver is not available on the host platform.
  */
 object BrowserFactory {

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
@@ -57,8 +57,10 @@ import BrowserFactory.UninitializedDriver
  * class ExampleSpec extends PlaySpec with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
  *
  *   // Override app if you need a Application with other than non-default parameters.
- *   implicit override lazy val app: Application =
- *     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+ *   implicit override lazy val app: Application = new GuiceApplicationBuilder()
+ *       .configure("foo" -> "bar", "ehcacheplugin" -> "disabled")
+ *       .router(Router.from(TestRoute))
+ *       .build()
  *
  *   "The OneBrowserPerSuite trait" must {
  *     "provide an Application" in {

--- a/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
+++ b/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
@@ -88,8 +88,11 @@ import org.openqa.selenium.safari.SafariDriver
  * class ExampleSpec extends MixedPlaySpec {
  *
  *   // Some helper methods
- *   def buildApp[A](elems: (String, String)*) =
- *     new GuiceApplicationBuilder().configure(Map(elems:_*)).additionalRouter(Router.from(TestRoute)).build()
+ *   def buildApp[A](elems: (String, String)*) = new GuiceApplicationBuilder()
+ *     .configure(Map(elems:_*))
+ *     .router(Router.from(TestRoute))
+ *     .build()
+ *
  *   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
  *
  *   "The App function" must {

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
@@ -65,8 +65,10 @@ import org.openqa.selenium.chrome.ChromeDriver
  * class ExampleSpec extends PlaySpec with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
  *
  *   // Override app if you need a Application with other than non-default parameters.
- *   implicit override lazy val app: Application =
- *     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+ *   implicit override lazy val app: Application = new GuiceApplicationBuilder()
+ *     .configure("foo" -> "bar", "ehcacheplugin" -> "disabled")
+ *     .router(Router.from(TestRoute))
+ *     .build()
  *
  *   "The OneBrowserPerSuite trait" must {
  *     "provide an Application" in {

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
@@ -58,8 +58,10 @@ import BrowserFactory.UninitializedDriver
  * class ExampleSpec extends PlaySpec with OneServerPerTest with OneBrowserPerTest with FirefoxFactory {
  *
  *   // Override newAppForTest if you need an Application with other than non-default parameters.
- *   override def newAppForTest(testData: TestData): Application =
- *     new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).additionalRouter(Router.from(TestRoute)).build()
+ *   override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder()
+ *     .configure(Map("ehcacheplugin" -> "disabled"))
+ *     .router(Router.from(TestRoute))
+ *     .build()
  *
  *   "The OneBrowserPerTest trait" must {
  *     "provide an Application" in {

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
@@ -16,6 +16,7 @@
 package org.scalatestplus.play
 
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import org.scalatest._
 
@@ -109,10 +110,10 @@ import org.scalatest._
  * }
  *
  * // These are the nested suites
+ *
  * @DoNotDiscover class OneSpec extends PlaySpec with ConfiguredServer
  * @DoNotDiscover class TwoSpec extends PlaySpec with ConfiguredServer
  * @DoNotDiscover class RedSpec extends PlaySpec with ConfiguredServer
- *
  * @DoNotDiscover
  * class BlueSpec extends PlaySpec with ConfiguredServer {
  *
@@ -150,7 +151,7 @@ trait OneServerPerSuite extends SuiteMixin with ServerProvider { this: Suite =>
    * This trait's implementation initializes this `lazy` `val` with a new instance of `FakeApplication` with
    * parameters set to their defaults. Override this `lazy` `val` if you need a `Application` created with non-default parameter values.
    */
-  implicit lazy val app: Application = new FakeApplication()
+  implicit lazy val app: Application = new GuiceApplicationBuilder().build()
 
   /**
    * The port used by the `TestServer`.  By default this will be set to the result returned from
@@ -162,6 +163,7 @@ trait OneServerPerSuite extends SuiteMixin with ServerProvider { this: Suite =>
    * Invokes `start` on a new `TestServer` created with the `Application` provided by `app` and the
    * port number defined by `port`, places the `Application` and port number into the `ConfigMap` under the keys
    * `org.scalatestplus.play.app` and `org.scalatestplus.play.port`, respectively, to make
+ *
    * them available to nested suites; calls `super.run`; and lastly ensures the `Application and test server are stopped after
    * all tests and nested suites have completed.
    *

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
@@ -16,6 +16,7 @@
 package org.scalatestplus.play
 
 import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test._
 import org.scalatest._
 
@@ -46,8 +47,10 @@ import org.scalatest._
  * class ExampleSpec extends PlaySpec with OneServerPerTest {
  *
  *   // Override newAppForTest if you need a FakeApplication with other than non-default parameters.
- *   implicit override def newAppForTest(testData: TestData): Application =
- *     new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).additionalRouter(Router.from(TestRoute)).build()
+ *   implicit override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder()
+ *     .configure(Map("ehcacheplugin" -> "disabled"))
+ *     .router(Router.from(TestRoute))
+ *     .build()
  *
  *   "The OneServerPerTest trait" must {
  *     "provide a FakeApplication" in {
@@ -88,7 +91,7 @@ trait OneServerPerTest extends SuiteMixin with ServerProvider { this: Suite =>
    * Creates new instance of `Application` with parameters set to their defaults. Override this method if you
    * need an `Application` created with non-default parameter values.
    */
-  def newAppForTest(testData: TestData): Application = new FakeApplication()
+  def newAppForTest(testData: TestData): Application = GuiceApplicationBuilder().build()
 
   /**
    * The port used by the `TestServer`.  By default this will be set to the result returned from

--- a/module/src/test/scala/org/scalatestplus/play/ChromeFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ChromeFactorySpec.scala
@@ -26,7 +26,7 @@ import play.api.routing._
 class ChromeFactorySpec extends UnitSpec with OneServerPerSuite with OneBrowserPerSuite with ChromeFactory {
 
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
@@ -27,7 +27,7 @@ class ConfiguredServerWithAllBrowsersPerSuiteSpec extends Suites(
 )
 with OneServerPerSuite {
   override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }
 
 @DoNotDiscover

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
@@ -26,7 +26,7 @@ class ConfiguredServerWithAllBrowsersPerTestSpec extends Suites(
 )
 with OneServerPerSuite {
   override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }
 
 @DoNotDiscover

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithConfiguredBrowserSpec.scala
@@ -27,7 +27,7 @@ class ConfiguredServerWithConfiguredBrowserSpec extends UnitSpec with Sequential
   override def nestedSuites = Vector(new ConfiguredServerWithConfiguredBrowserNestedSpec)
 
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 }

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
@@ -26,7 +26,7 @@ class ConfiguredServerWithOneBrowserPerSuiteSpec extends Suites(
   new ConfiguredServerWithOneBrowserPerSuiteNestedSpec 
 ) with OneServerPerSuite {
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }
 
 @DoNotDiscover

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
@@ -25,7 +25,7 @@ class ConfiguredServerWithOneBrowserPerTestSpec extends Suites(
   new ConfiguredServerWithOneBrowserPerTestNestedSpec 
 ) with OneServerPerSuite {
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }
 
 @DoNotDiscover

--- a/module/src/test/scala/org/scalatestplus/play/HtmlUnitFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/HtmlUnitFactorySpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class HtmlUnitFactorySpec extends UnitSpec with OneServerPerSuite with OneBrowserPerSuite with HtmlUnitFactory {
 
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/InternetExplorerFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/InternetExplorerFactorySpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class InternetExplorerFactorySpec extends UnitSpec with OneServerPerSuite with OneBrowserPerSuite with InternetExplorerFactory {
 
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   // Doesn't need synchronization because set by withFixture and checked by the test

--- a/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
@@ -29,7 +29,7 @@ import scala.concurrent.Future
 class MixedFixtureSpec extends MixedSpec {
 
   def buildApp[A](elems: (String, String)*) =
-    new GuiceApplicationBuilder().configure(Map(elems:_*)).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map(elems:_*)).router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The App function" must {

--- a/module/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
@@ -23,7 +23,7 @@ import play.api.routing._
 class MixedFixturesWsScalaTestClientSpec extends MixedSpec with ScalaFutures {
 
   def app =
-    new GuiceApplicationBuilder().configure(Map("foo" -> "bar", "ehcacheplugin" -> "disabled")).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map("foo" -> "bar", "ehcacheplugin" -> "disabled")).router(Router.from(TestRoute)).build()
 
   "WsScalaTestClient" when {
 

--- a/module/src/test/scala/org/scalatestplus/play/MixedPlaySpecSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedPlaySpecSpec.scala
@@ -33,7 +33,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
   }
 
   def buildApp[A](elems: (String, String)*) =
-    new GuiceApplicationBuilder().configure(Map(elems:_*)).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map(elems:_*)).router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/OneChromeBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneChromeBrowserPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneChromeFactoryPerTestSpec extends UnitSpec with OneServerPerTest with OneBrowserPerTest with ChromeFactory {
 
   implicit override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/OneHtmlUnitBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneHtmlUnitBrowserPerTestSpec.scala
@@ -23,8 +23,8 @@ import play.api.routing._
 
 class OneHtmlUnitFactoryPerTestSpec extends UnitSpec with OneServerPerTest with OneBrowserPerTest with HtmlUnitFactory {
 
-  implicit override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+  implicit override def newAppForTest(testData: TestData): Application =
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
@@ -41,7 +41,6 @@ class OneHtmlUnitFactoryPerTestSpec extends UnitSpec with OneServerPerTest with 
     "provide the port" in {
       port mustBe Helpers.testServerPort
     }
-    import Helpers._
     "send 404 on a bad request" in {
       import java.net._
       val url = new URL("http://localhost:" + port + "/boum")

--- a/module/src/test/scala/org/scalatestplus/play/OneInternetExplorerBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneInternetExplorerBrowserPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneInternetExplorerFactoryPerTestSpec extends UnitSpec with OneServerPerTest with OneBrowserPerTest with InternetExplorerFactory {
 
   implicit override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/OneSafariBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneSafariBrowserPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneSafariBrowserPerTestSpec extends UnitSpec with OneServerPerTest with OneBrowserPerTest with SafariFactory {
 
   implicit override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerSuiteSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneServerPerSuiteWithAllBrowsersPerSuiteSpec extends UnitSpec with OneServerPerSuite with AllBrowsersPerSuite {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   var theWebDriver: WebDriver = null

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerTestSpec.scala
@@ -23,7 +23,7 @@ import play.api.routing._
 class OneServerPerSuiteWithAllBrowsersPerTestSpec extends UnitSpec with OneServerPerSuite with AllBrowsersPerTest {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithConfiguredBrowserSpec.scala
@@ -27,7 +27,7 @@ class OneServerPerSuiteWithConfiguredBrowserSpec extends UnitSpec with Sequentia
   override def nestedSuites = Vector(new OneServerPerSuiteWithConfiguredBrowserNestedSpec)
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 }
 

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerSuiteSpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class OneServerPerSuiteWithOneBrowserPerSuiteSpec extends UnitSpec with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   // Doesn't need synchronization because set by withFixture and checked by the test

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneServerPerSuiteWithOneBrowserPerTestSpec extends UnitSpec with OneServerPerSuite with OneBrowserPerTest with FirefoxFactory {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The OneBrowserPerTest trait" must {

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestSpec.scala
@@ -22,7 +22,7 @@ import play.api.inject.guice._
 
 class OneServerPerTestSpec extends UnitSpec with OneServerPerTest {
 
-  implicit override def newAppForTest(testData: TestData) = new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").build()
+  implicit override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The OneServerPerTest trait" must {
@@ -38,7 +38,6 @@ class OneServerPerTestSpec extends UnitSpec with OneServerPerTest {
     "provide the port" in {
       port mustBe Helpers.testServerPort
     }
-    import Helpers._
     "send 404 on a bad request" in {
       import java.net._
       val url = new URL("http://localhost:" + port + "/boum")

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerSuiteSpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class OneServerPerTestWithAllBrowsersPerSuiteSpec extends UnitSpec with OneServerPerTest with AllBrowsersPerSuite {
 
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   var theWebDriver: WebDriver = null

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneServerPerTestWithAllBrowsersPerTestSpec extends UnitSpec with OneServerPerTest with AllBrowsersPerTest {
 
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithConfiguredBrowserSpec.scala
@@ -27,7 +27,7 @@ class OneServerPerTestWithConfiguredBrowserSpec extends UnitSpec with Sequential
   override def nestedSuites = Vector(new OneServerPerTestWithConfiguredBrowserNestedSpec)
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 }
 

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerSuiteSpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class OneServerPerTestWithOneBrowserPerSuiteSpec extends UnitSpec with OneServerPerTest with OneBrowserPerSuite with FirefoxFactory {
 
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   // Doesn't need synchronization because set by withFixture and checked by the test

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerTestSpec.scala
@@ -24,7 +24,7 @@ import play.api.routing._
 class OneServerPerTestWithOneBrowserPerTestSpec extends UnitSpec with OneServerPerTest with OneBrowserPerTest with FirefoxFactory {
 
   override def newAppForTest(testData: TestData) =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The OneBrowserPerTest trait" must {

--- a/module/src/test/scala/org/scalatestplus/play/SafariFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/SafariFactorySpec.scala
@@ -25,7 +25,7 @@ import play.api.routing._
 class SafariFactorySpec extends UnitSpec with OneServerPerSuite with OneBrowserPerSuite with SafariFactory {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   // Doesn't need synchronization because set by withFixture and checked by the test

--- a/module/src/test/scala/org/scalatestplus/play/ServerSpecSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ServerSpecSpec.scala
@@ -22,7 +22,7 @@ import play.api.inject.guice._
 
 class ServerSpecSpec extends ServerSpec {
 
-  implicit override def newAppForTest(testData: TestData) = new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").build()
+  implicit override def newAppForTest(testData: TestData): Application = new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The ServerFixture" must {

--- a/module/src/test/scala/org/scalatestplus/play/WsScalaTestClientSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/WsScalaTestClientSpec.scala
@@ -23,7 +23,7 @@ import play.api.routing._
 class WsScalaTestClientSpec extends UnitSpec with OneServerPerSuite with ScalaFutures with IntegrationPatience {
 
   implicit override lazy val app =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   "WsScalaTestClient's" must {
 

--- a/module/src/test/scala/org/scalatestplus/play/examples/allbrowserspersuite/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/allbrowserspersuite/ExampleSpec.scala
@@ -27,7 +27,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with AllBrowsersPerSui
   // Override app if you need an Application with other than
   // default parameters.
   implicit override lazy val app =
-    new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").router(Router.from(TestRoute)).build()
 
   // Place tests you want run in different browsers in the `sharedTests` method:
   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/test/scala/org/scalatestplus/play/examples/allbrowserspertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/allbrowserspertest/ExampleSpec.scala
@@ -27,7 +27,7 @@ class ExampleSpec extends PlaySpec with OneServerPerTest with AllBrowsersPerTest
 
   // Override newAppForTest if you need a Application with other than non-default parameters.
   override def newAppForTest(testData: TestData): Application =
-     new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").additionalRouter(Router.from(TestRoute)).build()
+     new GuiceApplicationBuilder().disable[EhCacheModule].configure("foo" -> "bar").router(Router.from(TestRoute)).build()
 
   // Place tests you want run in different browsers in the `sharedTests` method:
   def sharedTests(browser: BrowserInfo) = {

--- a/module/src/test/scala/org/scalatestplus/play/examples/mixedfixtures/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/mixedfixtures/ExampleSpec.scala
@@ -25,7 +25,7 @@ class ExampleSpec extends MixedPlaySpec {
 
   // Some helper methods
   def buildApp[A](elems: (String, String)*) =
-    new GuiceApplicationBuilder().configure(Map(elems:_*)).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map(elems:_*)).router(Router.from(TestRoute)).build()
   def getConfig(key: String)(implicit app: Application) = app.configuration.getString(key)
 
   "The App function" must {

--- a/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/ExampleSpec.scala
@@ -27,7 +27,7 @@ class ExampleSpec extends PlaySpec with OneServerPerSuite with OneBrowserPerSuit
 
   // Override app if you need a Application with other than non-default parameters.
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   "The OneBrowserPerSuite trait" must {
     "provide an Application" in {

--- a/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/MultiBrowserExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/MultiBrowserExampleSpec.scala
@@ -28,7 +28,7 @@ abstract class MultiBrowserExampleSpec extends PlaySpec with OneServerPerSuite w
 
   // Override app if you need an Application with other than non-default parameters.
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 
   "The OneBrowserPerSuite trait" must {
     "provide an Application" in {

--- a/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/NestedExampleSpec.scala
@@ -31,7 +31,7 @@ class NestedExampleSpec extends Suites(
 ) with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
   // Override app if you need an Application with other than non-default parameters.
   implicit override lazy val app: Application =
-    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }
  
 // These are the nested suites

--- a/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpertest/ExampleSpec.scala
@@ -28,7 +28,7 @@ class ExampleSpec extends PlaySpec with OneServerPerTest with OneBrowserPerTest 
 
   // Override newAppForTest if you need an Application with other than non-default parameters.
   override def newAppForTest(testData: TestData): Application =
-    new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).router(Router.from(TestRoute)).build()
 
   "The OneBrowserPerTest trait" must {
     "provide an Application" in {

--- a/module/src/test/scala/org/scalatestplus/play/examples/oneserverpertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/oneserverpertest/ExampleSpec.scala
@@ -26,7 +26,7 @@ class ExampleSpec extends PlaySpec with OneServerPerTest {
 
   // Override newAppForTest if you need a FakeApplication with other than non-default parameters.
   implicit override def newAppForTest(testData: TestData): Application =
-    new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).additionalRouter(Router.from(TestRoute)).build()
+    new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).router(Router.from(TestRoute)).build()
 
   "The OneServerPerTest trait" must {
     "provide a FakeApplication" in {


### PR DESCRIPTION
1. Remove use of deprecated code at the test examples
2. Update links to the most recent version of ScalaTest
3. Correct which dependency must be added to the projects

Also, I've added a LICENSE.txt file to the root of the project, just to make more clear to users which license is being used here.