### PR TITLE
Port to Scalatest3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val `scalatestplus-play` = project
   .settings(
     organization := "org.scalatestplus.play",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "3.0.0-RC2",
+      "org.scalatest" %% "scalatest" % "3.0.0",
       "com.typesafe.play" %% "play-test" % PlayVersion,
       "net.sourceforge.htmlunit" % "htmlunit" % "2.20", // adds support for jQuery 2.20; can be removed as soon as selenium-java has it in it's own dependencies
       "org.seleniumhq.selenium" % "selenium-java" % "2.48.2",

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val `scalatestplus-play` = project
   .settings(
     organization := "org.scalatestplus.play",
     libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % "2.2.6",
+      "org.scalatest" %% "scalatest" % "3.0.0-RC2",
       "com.typesafe.play" %% "play-test" % PlayVersion,
       "net.sourceforge.htmlunit" % "htmlunit" % "2.20", // adds support for jQuery 2.20; can be removed as soon as selenium-java has it in it's own dependencies
       "org.seleniumhq.selenium" % "selenium-java" % "2.48.2",

--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+resolvers ++= DefaultOptions.resolvers(snapshot = true)
+
 val PlayVersion = playVersion("2.5.0")
 
 lazy val `scalatestplus-play-root` = project

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
@@ -191,7 +191,7 @@ import org.openqa.selenium.chrome.ChromeDriver
  * [info] <span class="stGreen">The AllBrowsersPerSuite trait</span>
  * </pre>
  */
-trait AllBrowsersPerSuite extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience { this: Suite with ServerProvider =>
+trait AllBrowsersPerSuite extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience { this: TestSuite with ServerProvider =>
 
   /**
    * Method to provide `FirefoxProfile` for creating `FirefoxDriver`, you can override this method to

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
@@ -192,7 +192,7 @@ import org.openqa.selenium.chrome.ChromeDriver
  * [info] <span class="stGreen">The AllBrowsersPerTest trait</span>
  * </pre>
  */
-trait AllBrowsersPerTest extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience { this: Suite with ServerProvider =>
+trait AllBrowsersPerTest extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience { this: TestSuite with ServerProvider =>
 
   /**
    * Method to provide `FirefoxProfile` for creating `FirefoxDriver`, you can override this method to

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredServer.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredServer.scala
@@ -74,7 +74,7 @@ import play.api.{Play, Application}
  * }
  * </pre>
  */
-trait ConfiguredServer extends SuiteMixin with ServerProvider { this: Suite => 
+trait ConfiguredServer extends TestSuiteMixin with ServerProvider { this: TestSuite =>
 
   private var configuredApp: Application = _
 

--- a/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
+++ b/module/src/main/scala/org/scalatestplus/play/MixedFixtures.scala
@@ -258,7 +258,7 @@ import org.openqa.selenium.safari.SafariDriver
  * }
  * </pre>
  */
-trait MixedFixtures extends SuiteMixin with UnitFixture { this: fixture.Suite =>
+trait MixedFixtures extends TestSuiteMixin with UnitFixture { this: fixture.TestSuite =>
 
   /**
    * `NoArg` subclass that provides an `Application` fixture.

--- a/module/src/main/scala/org/scalatestplus/play/OneAppPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneAppPerTest.scala
@@ -62,7 +62,7 @@ import play.api.inject.guice._
  * }
  * </pre>
  */
-trait OneAppPerTest extends SuiteMixin { this: Suite => 
+trait OneAppPerTest extends TestSuiteMixin { this: TestSuite =>
 
   /**
    * Creates new instance of `Application` with parameters set to their defaults. Override this method if you

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
@@ -24,6 +24,7 @@ import org.openqa.selenium.WebDriver
 import BrowserFactory.UnavailableDriver
 import org.openqa.selenium.safari.SafariDriver
 import org.openqa.selenium.chrome.ChromeDriver
+import scala.util.Try
 
 /* TODO: Make ConfiguredBrowser require a ServerProvider also, I think. */
 
@@ -350,7 +351,7 @@ trait OneBrowserPerSuite extends SuiteMixin with WebBrowser with Eventually with
    * @return a `Status` object that indicates when all tests and nested suites started by this method have completed, and whether or not a failure occurred.
    */
   abstract override def run(testName: Option[String], args: Args): Status = {
-    val cleanup: Boolean => Unit = { _ =>
+    val cleanup: Try[Boolean] => Unit = { _ =>
       webDriver match {
         case _: UnavailableDriver => // do nothing for UnavailableDriver
         case safariDriver: SafariDriver => safariDriver.quit()
@@ -366,7 +367,7 @@ trait OneBrowserPerSuite extends SuiteMixin with WebBrowser with Eventually with
       status
     } catch {
       case ex: Throwable =>
-        cleanup(false)
+        cleanup(Try(false))
         throw ex
     }
   }

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
@@ -315,7 +315,7 @@ import scala.util.Try
  * [info] <span class="stGreen">The OneBrowserPerSuite trait</span>
  * </pre>
  */
-trait OneBrowserPerSuite extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience with BrowserFactory { this: Suite with ServerProvider =>
+trait OneBrowserPerSuite extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience with BrowserFactory { this: TestSuite with ServerProvider =>
 
   /**
    * An implicit instance of `WebDriver`, created by calling `createWebDriver`.  

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
@@ -95,7 +95,7 @@ import BrowserFactory.UninitializedDriver
  * }
  * </pre>
  */
-trait OneBrowserPerTest extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience with BrowserFactory { this: Suite with ServerProvider =>
+trait OneBrowserPerTest extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience with BrowserFactory { this: TestSuite with ServerProvider =>
 
   private var privateWebDriver: WebDriver = UninitializedDriver
 

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
@@ -143,7 +143,7 @@ import org.scalatest._
  * }
  * </pre>
  */
-trait OneServerPerSuite extends SuiteMixin with ServerProvider { this: Suite =>
+trait OneServerPerSuite extends TestSuiteMixin with ServerProvider { this: TestSuite =>
 
   /**
    * An implicit instance of `Application`.

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
@@ -78,7 +78,7 @@ import org.scalatest._
  * }
  * </pre>
  */
-trait OneServerPerTest extends SuiteMixin with ServerProvider { this: Suite =>
+trait OneServerPerTest extends TestSuiteMixin with ServerProvider { this: TestSuite =>
 
   private var privateApp: Application = _
 

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
@@ -23,8 +23,8 @@ import play.api.inject.guice._
 import play.api.routing._
 
 class ConfiguredServerWithAllBrowsersPerSuiteSpec extends Suites(
-  new ConfiguredServerWithAllBrowsersPerSuiteNestedSpec 
-)
+  new ConfiguredServerWithAllBrowsersPerSuiteNestedSpec
+) with TestSuite
 with OneServerPerSuite {
   override lazy val app: Application =
     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
@@ -22,8 +22,9 @@ import play.api.inject.guice._
 import play.api.routing._
 
 class ConfiguredServerWithAllBrowsersPerTestSpec extends Suites(
-  new ConfiguredServerWithAllBrowsersPerTestNestedSpec 
+  new ConfiguredServerWithAllBrowsersPerTestNestedSpec
 )
+with TestSuite
 with OneServerPerSuite {
   override lazy val app: Application =
     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
@@ -23,8 +23,8 @@ import play.api.inject.guice._
 import play.api.routing._
 
 class ConfiguredServerWithOneBrowserPerSuiteSpec extends Suites(
-  new ConfiguredServerWithOneBrowserPerSuiteNestedSpec 
-) with OneServerPerSuite {
+  new ConfiguredServerWithOneBrowserPerSuiteNestedSpec
+) with TestSuite with OneServerPerSuite {
   implicit override lazy val app: Application =
     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
@@ -22,8 +22,8 @@ import play.api.inject.guice._
 import play.api.routing._
 
 class ConfiguredServerWithOneBrowserPerTestSpec extends Suites(
-  new ConfiguredServerWithOneBrowserPerTestNestedSpec 
-) with OneServerPerSuite {
+  new ConfiguredServerWithOneBrowserPerTestNestedSpec
+) with TestSuite with OneServerPerSuite {
   implicit override lazy val app: Application =
     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()
 }

--- a/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/onebrowserpersuite/NestedExampleSpec.scala
@@ -28,7 +28,7 @@ class NestedExampleSpec extends Suites(
   new TwoSpec,
   new RedSpec,
   new BlueSpec
-) with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
+) with TestSuite with OneServerPerSuite with OneBrowserPerSuite with FirefoxFactory {
   // Override app if you need an Application with other than non-default parameters.
   implicit override lazy val app: Application =
     new GuiceApplicationBuilder().configure("foo" -> "bar", "ehcacheplugin" -> "disabled").router(Router.from(TestRoute)).build()

--- a/module/src/test/scala/org/scalatestplus/play/examples/oneserverpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/oneserverpersuite/NestedExampleSpec.scala
@@ -27,7 +27,7 @@ class NestedExampleSpec extends Suites(
   new TwoSpec,
   new RedSpec,
   new BlueSpec
-) with OneServerPerSuite {
+) with TestSuite with OneServerPerSuite {
   // Override app if you need an Application with other than non-default parameters.
   implicit override lazy val app: Application =
     new GuiceApplicationBuilder().configure(Map("ehcacheplugin" -> "disabled")).build()

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,4 @@
+resolvers ++= DefaultOptions.resolvers(snapshot = true)
+
 addSbtPlugin("com.typesafe.play" % "interplay" % sys.props.get("interplay.version").getOrElse("1.1.2"))
 addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.5.0"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.1"
+version in ThisBuild := "1.5.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.1-SNAPSHOT"
+version in ThisBuild := "1.5.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.2-SNAPSHOT"
+version in ThisBuild := "1.6.0-SNAPSHOT"


### PR DESCRIPTION
This is a work-in-progress but it seems to work. I've been using it and it seems to work. For scala.js users scalatest 3 is required, so when it's released it would be ideal to have a release of scalatestplus-play to go with it. 

Fixes #27, #55