### PR TITLE
Update the WsScalaTestClient for no implicit WS.

### DIFF
--- a/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
+++ b/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
@@ -15,8 +15,7 @@
  */
 package org.scalatestplus.play
 
-import play.api.Play.current
-import play.api.libs.ws.{WS, WSClient, WSRequest}
+import play.api.libs.ws.{WSClient, WSRequest}
 import play.api.mvc.Call
 
 /**
@@ -36,7 +35,7 @@ trait WsScalaTestClient {
    * @param portNumber the port number of the `TestServer`
    * @param wsClient the implicit WSClient
    */
-  def wsCall(call: Call)(implicit portNumber: PortNumber, wsClient: WSClient = WS.client): WSRequest = doCall(call.url, wsClient, portNumber)
+  def wsCall(call: Call)(implicit portNumber: PortNumber, wsClient: WSClient): WSRequest = doCall(call.url, wsClient, portNumber)
 
   /**
    * Construct a WS request for the given relative URL.
@@ -45,7 +44,7 @@ trait WsScalaTestClient {
    * @param portNumber the port number of the `TestServer`
    * @param wsClient the implicit WSClient
    */
-  def wsUrl(url: String)(implicit portNumber: PortNumber, wsClient: WSClient = WS.client): WSRequest = doCall(url, wsClient, portNumber)
+  def wsUrl(url: String)(implicit portNumber: PortNumber, wsClient: WSClient): WSRequest = doCall(url, wsClient, portNumber)
 
   private def doCall(url: String, wsClient: WSClient, portNumber: PortNumber) = {
     wsClient.url("http://localhost:" + portNumber.value + url)

--- a/module/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedFixturesWsScalaTestClientSpec.scala
@@ -18,12 +18,15 @@ package org.scalatestplus.play
 import org.scalatest.concurrent.ScalaFutures
 import play.api.mvc.Call
 import play.api.inject.guice._
+import play.api.libs.ws.WSClient
 import play.api.routing._
 
 class MixedFixturesWsScalaTestClientSpec extends MixedSpec with ScalaFutures {
 
   def app =
     new GuiceApplicationBuilder().configure(Map("foo" -> "bar", "ehcacheplugin" -> "disabled")).router(Router.from(TestRoute)).build()
+
+  implicit val ws: WSClient = app.injector.instanceOf(classOf[WSClient])
 
   "WsScalaTestClient" when {
 

--- a/module/src/test/scala/org/scalatestplus/play/WsScalaTestClientSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/WsScalaTestClientSpec.scala
@@ -19,6 +19,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 import play.api.mvc.Call
 import play.api.inject.guice._
+import play.api.libs.ws.WSClient
 import play.api.routing._
 
 class WsScalaTestClientSpec extends UnitSpec with GuiceOneServerPerSuite with ScalaFutures with IntegrationPatience {
@@ -29,6 +30,7 @@ class WsScalaTestClientSpec extends UnitSpec with GuiceOneServerPerSuite with Sc
   "WsScalaTestClient's" must {
 
     "wsUrl works correctly" in {
+      implicit val ws: WSClient = app.injector.instanceOf(classOf[WSClient])
       val futureResult = wsUrl("/testing").get
       val body = futureResult.futureValue.body
       val expectedBody =
@@ -42,6 +44,8 @@ class WsScalaTestClientSpec extends UnitSpec with GuiceOneServerPerSuite with Sc
     }
 
     "wsCall works correctly" in {
+      implicit val ws: WSClient = app.injector.instanceOf(classOf[WSClient])
+
       val futureResult = wsCall(Call("get", "/testing")).get
       val body = futureResult.futureValue.body
       val expectedBody =


### PR DESCRIPTION
Remove the implicit WS.client default parameter from WsScalaTestClient.  

Use of the default is problematic in 2.5.x since WS is deprecated, and will not compile at all against Play 2.6.x as the class does not exist.  

Also, vegemite tries to compile scalatestplus-play as part of the nightly build and use it against 2.6.x -- so this will fix the nightly build as well.