### PR TITLE
update play version to 2.6-RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ import interplay.ScalaVersions._
 
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
 
-val PlayVersion = playVersion("2.6.0-M5")
+val PlayVersion = playVersion("2.6.0-RC2")
 
 val ScalatestVersion = "3.0.3"
 val SeleniumVersion = "3.4.0"


### PR DESCRIPTION
when I use `GuiceOneServerPerSuite` with play-2.6-RC2, it cause this error.

```
[info]   java.lang.NoClassDefFoundError: play/core/server/ServerWithStop
[info]   at java.lang.ClassLoader.defineClass1(Native Method)
[info]   at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
[info]   at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
[info]   at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
[info]   at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
[info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
[info]   at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
[info]   at java.security.AccessController.doPrivileged(Native Method)
[info]   at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
[info]   at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
```

because, at play-2.6-M5, this class was exist, but at RC-2, it was changed.

■play-2.6-M5
https://github.com/playframework/playframework/blob/426f70f9cbc70cc857f15727f078dd3577e6ecd7/framework/src/build-link/src/main/java/play/core/server/ServerWithStop.java

■play-2.6-RC-2
https://github.com/playframework/playframework/tree/02bdd4b92eaa13502d2b5b80ae950d1d37e37e52/framework/src/build-link/src/main/java/play/core/server