### PR TITLE
Run Chrome in headless mode

### DIFF
--- a/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleOverrideBrowsersSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/allbrowserspersuite/ExampleOverrideBrowsersSpec.scala
@@ -17,7 +17,7 @@ class ExampleOverrideBrowsersSpec extends PlaySpec with GuiceOneServerPerSuite w
   override lazy val browsers =
     Vector(
       FirefoxInfo(firefoxProfile),
-      ChromeInfo
+      ChromeInfo()
     )
 
   // Override app if you need an Application with other than

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
@@ -204,7 +204,7 @@ trait AllBrowsersPerSuite extends TestSuiteMixin with WebBrowser with Eventually
       FirefoxInfo(firefoxProfile),
       SafariInfo,
       InternetExplorerInfo,
-      ChromeInfo,
+      ChromeInfo(),
       HtmlUnitInfo(true),
       PhantomJSInfo()
     )

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
@@ -204,7 +204,7 @@ trait AllBrowsersPerTest extends TestSuiteMixin with WebBrowser with Eventually 
       FirefoxInfo(firefoxProfile),
       SafariInfo,
       InternetExplorerInfo,
-      ChromeInfo,
+      ChromeInfo(),
       HtmlUnitInfo(true),
       PhantomJSInfo()
     )

--- a/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
@@ -144,7 +144,7 @@ case object InternetExplorerInfo extends BrowserInfo("[InternetExplorer]", "org.
  *
  * @param chromeOptions the `ChromeOptions` to use when creating new `ChromeDriver`s in the `createWebDriver` factory method.
  */
-case class ChromeInfo(chromeOptions: ChromeOptions = new ChromeOptions()) extends BrowserInfo("[Chrome]", "org.scalatest.tags.ChromeBrowser") {
+case class ChromeInfo(chromeOptions: ChromeOptions = ChromeFactory.createChromeOptions(true)) extends BrowserInfo("[Chrome]", "org.scalatest.tags.ChromeBrowser") {
 
   /**
    * Creates a new instance of a Selenium `ChromeDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes

--- a/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BrowserInfo.scala
@@ -18,6 +18,7 @@ package org.scalatestplus.play
 import java.util.logging.Level
 
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.chrome.ChromeOptions
 import org.openqa.selenium.firefox.{ FirefoxOptions, FirefoxProfile }
 import org.openqa.selenium.remote.DesiredCapabilities
 
@@ -140,8 +141,10 @@ case object InternetExplorerInfo extends BrowserInfo("[InternetExplorer]", "org.
  * use the `BrowserInfo`'s factory method to create `WebDriver`s as needed.
  * The `AllBrowsersPerSuite` and `AllBrowsersPerTest` traits use the  tag name to automatically tag any tests that use
  * a particular `WebDriver` with the appropriate tag so that tests can be dynamically filtered by the browser the use.
+ *
+ * @param chromeOptions the `ChromeOptions` to use when creating new `ChromeDriver`s in the `createWebDriver` factory method.
  */
-case object ChromeInfo extends BrowserInfo("[Chrome]", "org.scalatest.tags.ChromeBrowser") {
+case class ChromeInfo(chromeOptions: ChromeOptions = new ChromeOptions()) extends BrowserInfo("[Chrome]", "org.scalatest.tags.ChromeBrowser") {
 
   /**
    * Creates a new instance of a Selenium `ChromeDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes

--- a/module/src/main/scala/org/scalatestplus/play/ChromeFactory.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ChromeFactory.scala
@@ -16,7 +16,7 @@
 package org.scalatestplus.play
 
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.chrome.{ ChromeDriver, ChromeOptions }
 import BrowserFactory.UnavailableDriver
 
 /**
@@ -31,6 +31,12 @@ import BrowserFactory.UnavailableDriver
 trait ChromeFactory extends BrowserFactory {
 
   /**
+   * 'ChromeOptions' that is used to create new instance of 'ChromeDriver'.
+   * Override to provide a different `ChromeOptions`.
+   */
+  lazy val chromeOptions: ChromeOptions = new ChromeOptions()
+
+  /**
    * Creates a new instance of a Selenium `ChromeDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes
    * the exception that indicated the driver was not supported on the host platform and an appropriate
    * error message.
@@ -40,7 +46,7 @@ trait ChromeFactory extends BrowserFactory {
    */
   def createWebDriver(): WebDriver =
     try {
-      new ChromeDriver()
+      new ChromeDriver(chromeOptions)
     } catch {
       case ex: Throwable => UnavailableDriver(Some(ex), Resources("cantCreateChromeDriver", ex.getMessage))
     }

--- a/module/src/main/scala/org/scalatestplus/play/ChromeFactory.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ChromeFactory.scala
@@ -34,7 +34,7 @@ trait ChromeFactory extends BrowserFactory {
    * 'ChromeOptions' that is used to create new instance of 'ChromeDriver'.
    * Override to provide a different `ChromeOptions`.
    */
-  lazy val chromeOptions: ChromeOptions = new ChromeOptions()
+  lazy val chromeOptions: ChromeOptions = ChromeFactory.createChromeOptions(true)
 
   /**
    * Creates a new instance of a Selenium `ChromeDriver`, or returns a [[org.scalatestplus.play.BrowserFactory.UnavailableDriver BrowserFactory.UnavailableDriver]] that includes
@@ -55,5 +55,22 @@ trait ChromeFactory extends BrowserFactory {
 /**
  * Companion object to trait `ChromeFactory` that mixes in the trait.
  */
-object ChromeFactory extends ChromeFactory
+object ChromeFactory extends ChromeFactory {
 
+  /**
+   * Creates a new instance of `ChromeOptions`.
+   *
+   * @param headless whether or not to run Chrome in headless mode
+   * @return a new instance of `ChromeOptions`
+   */
+  def createChromeOptions(headless: Boolean): ChromeOptions = {
+    val options = new ChromeOptions
+    if (headless) {
+      // Windows environment requires `--disable-gpu` for now.
+      // See https://developers.google.com/web/updates/2017/04/headless-chrome?hl=en#cli
+      options.addArguments("--headless", "--disable-gpu")
+    }
+    options
+  }
+
+}

--- a/module/src/test/scala/org/scalatestplus/play/AllBrowsersPerSuiteBehaviorSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/AllBrowsersPerSuiteBehaviorSpec.scala
@@ -329,7 +329,7 @@ class AllBrowsersPerSuiteBehaviorSpec extends WordSpec {
       class ChromeTestSpec extends TestSpec {
         override lazy val browsers: IndexedSeq[BrowserInfo] =
           Vector(
-            ChromeInfo
+            ChromeInfo()
           )
       }
 

--- a/module/src/test/scala/org/scalatestplus/play/AllBrowsersPerTestBehaviorSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/AllBrowsersPerTestBehaviorSpec.scala
@@ -328,7 +328,7 @@ class AllBrowsersPerTestBehaviorSpec extends WordSpec {
       class ChromeTestSpec extends TestSpec {
         override lazy val browsers: IndexedSeq[BrowserInfo] =
           Vector(
-            ChromeInfo
+            ChromeInfo()
           )
       }
 


### PR DESCRIPTION
Though it is not difficult to define something like [`HeadlessChromeFactory`](https://gist.github.com/hirofumi/4c565b3d0e70b055e9c09ba0a851b4a4), it would be nice if there is an out-of-the-box support of headless mode.