### PR TITLE
Prevent deadlock when BaseOneServerPerTest is used

### DIFF
--- a/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerTest.scala
@@ -78,6 +78,8 @@ trait BaseOneServerPerTest extends TestSuiteMixin with ServerProvider { this: Te
   @volatile private var privateApp: Application = _
   @volatile private var privateServer: RunningServer = _
 
+  private[this] val lock = new Object()
+
   /**
    * Implicit method that returns the `Application` instance for the current test.
    */
@@ -113,7 +115,7 @@ trait BaseOneServerPerTest extends TestSuiteMixin with ServerProvider { this: Te
   abstract override def withFixture(test: NoArgTest) = {
     // Need to synchronize within a suite because we store current app/server in fields in the class
     // Could possibly pass app/server info in a ScalaTest object?
-    synchronized {
+    lock.synchronized {
       privateApp = newAppForTest(test)
       privateServer = newServerForTest(app, test)
       try super.withFixture(test) finally {

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestComponentSynchronizationSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestComponentSynchronizationSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2001-2016 Artima, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.scalatestplus.play
+
+  import java.util.concurrent.TimeoutException
+
+  import org.scalatest.{FlatSpec, MustMatchers}
+  import org.scalatestplus.play.components.OneServerPerTestWithComponents
+  import play.api.mvc.Results
+  import play.api.routing.Router
+  import play.api.{BuiltInComponents, BuiltInComponentsFromContext, NoHttpFiltersComponents}
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration._
+  import scala.concurrent.{Await, Future}
+
+class OneServerPerTestComponentSynchronizationSpec extends FlatSpec with MustMatchers
+    with OneServerPerTestWithComponents {
+
+  override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
+
+    lazy val router: Router = Router.from({
+      case _ => defaultActionBuilder {
+        Results.Ok("success!")
+      }
+    })
+
+  }
+
+  lazy val sum: Int = 1+1
+
+  "A asynchronous test based on OneServerPerTestWithComponents trait" must "not result in dead lock when the test initializes lazy val" in {
+    val action = Future {
+      sum mustBe 2
+    }
+
+    try {
+      Await.result(action, 1 second)
+    } catch {
+      case _: TimeoutException =>
+        fail()
+    }
+    succeed
+  }
+
+}
+


### PR DESCRIPTION
`BaseOneServerPerTest` in combination with mixins which have lazy vals can result in deadlock when asynchronous test is executed. I encountered such issue in my project for following assertion:
```scala
"some string".mustNot(equal("other string"))
```

after upgrade  to Play 2.7 and ScalaTest+ 4.0.1