### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
 
-
 addons:
   firefox: "latest"
   chrome: stable
@@ -47,14 +46,3 @@ notifications:
     urls: https://webhooks.gitter.im/e/d2c8a242a2615f659595
     on_success: always
     on_failure: always
-
-addons:
-  firefox: "latest"
-  chrome: stable
-  apt:
-    packages:
-    - unzip
-    - dbus-x11
-  sauce_connect:
-    username: will_sargent
-    access_key: d809febf-5037-4857-aefb-ac652b4c5315

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ env:
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
-s
+
+
 addons:
   firefox: "latest"
   chrome: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,20 +17,7 @@ env:
 
 before_install: curl -Ls https://git.io/jabba | bash && . ~/.jabba/jabba.sh
 install: jabba install "$TRAVIS_JDK" && jabba use "$_" && java -Xmx32m -version
-
-before_script:
-  # See https://github.com/SeleniumHQ/docker-selenium/issues/87
-  - export DBUS_SESSION_BUS_ADDRESS=/dev/null
-  - export CHROME_BIN=/usr/bin/google-chrome
-  - "export DISPLAY=:99.0"
-  - "Xvfb :99 +extension RANDR 2>/dev/null &"
-  - sleep 5 # give xvfb some time to start
-  - "mkdir -p ~/tmp/bin"
-  - "pushd ~/tmp/bin && wget -c https://chromedriver.storage.googleapis.com/2.44/chromedriver_linux64.zip && unzip chromedriver_linux64.zip && popd"
-  - "pushd ~/tmp/bin && wget -c https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz && tar -xzvf geckodriver-v0.23.0-linux64.tar.gz && popd"
-  - "chmod -vv +x ~/tmp/bin/*"
-  - "export PATH=$HOME/tmp/bin:$PATH"
-
+s
 addons:
   firefox: "latest"
   chrome: stable

--- a/scripts/build
+++ b/scripts/build
@@ -26,5 +26,9 @@ export JAVA_OPTS="-Xmx2G -Xss2M -XX:MaxMetaspaceSize=512M -XX:ReservedCodeCacheS
 ADDITIONAL_SBT_ARGUMENTS=${ADDITIONAL_SBT_ARGUMENTS:-""}
 
 build() {
-  "$SBT" ${ADDITIONAL_SBT_ARGUMENTS} ++${SCALA_VERSION} "$@" | grep --line-buffered -v 'Resolving \|Generating \|addons\.\|GConf-WARNING'
+#  "$SBT" ${ADDITIONAL_SBT_ARGUMENTS} ++${SCALA_VERSION} "$@" | grep --line-buffered -v 'Resolving \|Generating \|addons\.\|GConf-WARNING'
+  echo ${ADDITIONAL_SBT_ARGUMENTS}
+  echo $TRAVIS_JDK
+  echo $JAVA_OPTS
+  echo ++${SCALA_VERSION} "$@"
 }


### PR DESCRIPTION
The build in travis is repeating the same `SCRIPT` (`sbt test`) instead of using the configured in the appropriate axis of the build matrix. 

See https://travis-ci.com/playframework/scalatestplus-play/builds/106790168, and in particular see https://travis-ci.com/playframework/scalatestplus-play/jobs/189765082#L548 which invokes `sbt test` instead of `sbt validateDocs`.