### PR TITLE
Clarify docs about testing models

### DIFF
--- a/docs/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithScalaTest.md
+++ b/docs/manual/working/scalaGuide/main/tests/ScalaFunctionalTestingWithScalaTest.md
@@ -119,7 +119,7 @@ Instead of calling the `Action` yourself, you can let the `Router` do it:
 
 ## Testing a model
 
-If you are using an SQL database, you can replace the database connection with an in-memory instance of an H2 database using `inMemoryDatabase`.
+If you are using an SQL database, you can replace the database connection with an in-memory instance of an H2 database using `Helpers#inMemoryDatabase`.
 
 @[scalafunctionaltest-testmodel](code/ScalaFunctionalTestSpec.scala)
 


### PR DESCRIPTION
When reading the docs about testing on playframework.com, it was not directly obvious to me that `inMemoryDatabase` is a member of the `Helpers` object. Even though the doc page technically says:

> Most of these can be found either in the play.api.test package or in the Helpers object

at the top of the page, I still think it is helpful to be explicit here, close to the code snippet. 