### PR TITLE
#112 - don't extend sync line of suites

### DIFF
--- a/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerSuite.scala
@@ -17,15 +17,15 @@ package org.scalatestplus.play
 
 import org.scalatest.Args
 import org.scalatest.Status
-import org.scalatest.TestSuite
-import org.scalatest.TestSuiteMixin
+import org.scalatest.Suite
+import org.scalatest.SuiteMixin
 import play.api.Application
 import play.api.Play
 
 /**
  * The base abstract trait for one app per suite.
  */
-trait BaseOneAppPerSuite extends TestSuiteMixin { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneAppPerSuite extends SuiteMixin { this: Suite with FakeApplicationFactory =>
 
   /**
    * An implicit instance of `Application`.

--- a/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerSuite.scala
@@ -28,7 +28,7 @@ import play.api.test._
  * `Application` with non-default parameters, override `app`. If it needs a different port number,
  * override `port`.
  *
- * This `TestSuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
+ * This `SuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
  * before executing the `Suite` via a call to `super.run`.
  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
  * under the key `org.scalatestplus.play.app` and to the port number provided by `port` under the key
@@ -134,7 +134,7 @@ import play.api.test._
  * }
  * </pre>
  */
-trait BaseOneServerPerSuite extends TestSuiteMixin with ServerProvider { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneServerPerSuite extends SuiteMixin with ServerProvider { this: Suite with FakeApplicationFactory =>
 
   /**
    * An implicit instance of `Application`.

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredApp.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredApp.scala
@@ -56,7 +56,7 @@ import play.api.Application
  * }
  * </pre>
  */
-trait ConfiguredApp extends TestSuiteMixin { this: TestSuite =>
+trait ConfiguredApp extends SuiteMixin { this: Suite =>
 
   private var configuredApp: Application = _
 

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
@@ -87,8 +87,8 @@ import org.scalatestplus.selenium.WebBrowser
  * }
  * </pre>
  */
-trait ConfiguredBrowser extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience {
-  this: TestSuite with ServerProvider =>
+trait ConfiguredBrowser extends SuiteMixin with WebBrowser with Eventually with IntegrationPatience {
+  this: Suite with ServerProvider =>
 
   private var configuredWebDriver: WebDriver = UninitializedDriver
 

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredServer.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredServer.scala
@@ -73,7 +73,7 @@ import play.core.server.ServerEndpoints
  * }
  * </pre>
  */
-trait ConfiguredServer extends TestSuiteMixin with ServerProvider { this: TestSuite =>
+trait ConfiguredServer extends SuiteMixin with ServerProvider { this: Suite =>
 
   private var configuredApp: Application = _
 

--- a/module/src/main/scala/org/scalatestplus/play/OneAppPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneAppPerSuite.scala
@@ -22,6 +22,6 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
  * Synonym for GuiceOneAppPerSuite.
  */
 @deprecated("Use GuiceOneAppPerSuite instead", "2.0.0")
-trait OneAppPerSuite extends GuiceOneAppPerSuite { this: TestSuite =>
+trait OneAppPerSuite extends GuiceOneAppPerSuite { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/OneAppPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneAppPerTest.scala
@@ -22,6 +22,6 @@ import org.scalatestplus.play.guice.GuiceOneAppPerTest
  * Synonym for GuiceOneAppPerTest
  */
 @deprecated("Use GuiceOneAppPerTest instead", "2.0.0")
-trait OneAppPerTest extends GuiceOneAppPerTest { this: TestSuite =>
+trait OneAppPerTest extends GuiceOneAppPerTest { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
@@ -31,7 +31,7 @@ import scala.util.Try
 /**
  * Trait that provides a new Selenium `WebDriver` instance per ScalaTest `Suite`.
  *
- * This `TestSuiteMixin` trait's overridden `run` method
+ * This `SuiteMixin` trait's overridden `run` method
  * places a reference to the `WebDriver` provided by `webDriver` under the key `org.scalatestplus.play.webDriver`.
  * This allows any nested `Suite`s to access the `Suite`'s
  * `WebDriver` as well, most easily by having the nested `Suite`s mix in the
@@ -305,11 +305,12 @@ import scala.util.Try
  * </pre>
  */
 trait OneBrowserPerSuite
-    extends TestSuiteMixin
+    extends SuiteMixin
+    with BeforeAndAfterEach
     with WebBrowser
     with Eventually
     with IntegrationPatience
-    with BrowserFactory { this: TestSuite with ServerProvider =>
+    with BrowserFactory { this: Suite with ServerProvider =>
 
   /**
    * An implicit instance of `WebDriver`, created by calling `createWebDriver`.
@@ -322,14 +323,14 @@ trait OneBrowserPerSuite
    * Automatically cancels tests with an appropriate error message when the `webDriver` field is a `UnavailableDriver`,
    * else calls `super.withFixture(test)`
    */
-  abstract override def withFixture(test: NoArgTest): Outcome = {
+  override def beforeEach(): Unit = {
     webDriver match {
       case UnavailableDriver(ex, errorMessage) =>
         ex match {
           case Some(e) => cancel(errorMessage, e)
           case None    => cancel(errorMessage)
         }
-      case _ => super.withFixture(test)
+      case _ => super.beforeEach()
     }
   }
 

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerSuite.scala
@@ -15,13 +15,13 @@
  */
 package org.scalatestplus.play
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
 
 /**
  * Synonym for GuiceOneServerPerSuite.
  */
 @deprecated("Use GuiceOneServerPerSuite instead", "2.0.0")
-trait OneServerPerSuite extends GuiceOneServerPerSuite { this: TestSuite =>
+trait OneServerPerSuite extends GuiceOneServerPerSuite { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneServerPerTest.scala
@@ -22,6 +22,6 @@ import org.scalatestplus.play.guice.GuiceOneServerPerTest
  * Synonym for GuiceOneServerPerTest
  */
 @deprecated("Use GuiceOneServerPerTest instead", "2.0.0")
-trait OneServerPerTest extends GuiceOneServerPerTest { this: TestSuite =>
+trait OneServerPerTest extends GuiceOneServerPerTest { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/components/OneAppPerSuiteWithComponents.scala
+++ b/module/src/main/scala/org/scalatestplus/play/components/OneAppPerSuiteWithComponents.scala
@@ -1,6 +1,6 @@
 package org.scalatestplus.play.components
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneAppPerSuite
 import org.scalatestplus.play.FakeApplicationFactory
 import play.api.Application
@@ -12,7 +12,7 @@ import play.api.Application
  *
  * By default, this trait creates a new `Application` for the `Suite` according to the components defined in the test.
  *
- * This `TestSuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
+ * This `SuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
  * `Application` provided by `app`, before executing the `Suite` via a call to `super.run`.
  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
  * under the key `org.scalatestplus.play.app`.  This allows any nested `Suite`s to access the `Suite`'s
@@ -70,7 +70,7 @@ import play.api.Application
  * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredApp`. Here's an example:
  *
  * <pre class="stHighlight">
- * import org.scalatest.{DoNotDiscover, Suites, TestSuite}
+ * import org.scalatest.{DoNotDiscover, Suites, Suite}
  * import org.scalatestplus.play.components.OneAppPerSuiteWithComponents
  * import org.scalatestplus.play.{ConfiguredApp, PlaySpec}
  * import play.api._
@@ -86,7 +86,7 @@ import play.api.Application
  *   new TwoSpec,
  *   new RedSpec,
  *   new BlueSpec
- * ) with OneAppPerSuiteWithComponents with TestSuite {
+ * ) with OneAppPerSuiteWithComponents with Suite {
  *   // Override fakeApplication if you need an Application with other than non-default parameters.
  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
  *
@@ -137,7 +137,7 @@ trait OneAppPerSuiteWithComponents
     extends BaseOneAppPerSuite
     with WithApplicationComponents
     with FakeApplicationFactory {
-  this: TestSuite =>
+  this: Suite =>
 
   override def fakeApplication(): Application = newApplication
 }

--- a/module/src/main/scala/org/scalatestplus/play/components/OneAppPerTestWithComponents.scala
+++ b/module/src/main/scala/org/scalatestplus/play/components/OneAppPerTestWithComponents.scala
@@ -1,7 +1,7 @@
 package org.scalatestplus.play.components
 
-import org.scalatest.TestSuite
-import org.scalatest.TestSuiteMixin
+import org.scalatest.Suite
+import org.scalatest.SuiteMixin
 import org.scalatestplus.play.BaseOneAppPerTest
 import org.scalatestplus.play.FakeApplicationFactory
 import play.api.Application
@@ -11,7 +11,7 @@ import play.api.Application
  *
  * Trait that provides a new `Application` instance for each test.
  *
- * This `TestSuiteMixin` trait's overridden `withFixture` method creates a new `Application`
+ * This `SuiteMixin` trait's overridden `withFixture` method creates a new `Application`
  * before each test and ensures it is cleaned up after the test has completed. You can
  * access the `Application` from your tests as method `app` (which is marked implicit).
  *
@@ -63,8 +63,8 @@ trait OneAppPerTestWithComponents
     extends BaseOneAppPerTest
     with WithApplicationComponents
     with FakeApplicationFactory
-    with TestSuiteMixin {
-  this: TestSuite =>
+    with SuiteMixin {
+  this: Suite =>
 
   override def fakeApplication(): Application = newApplication
 }

--- a/module/src/main/scala/org/scalatestplus/play/components/OneServerPerSuiteWithComponents.scala
+++ b/module/src/main/scala/org/scalatestplus/play/components/OneServerPerSuiteWithComponents.scala
@@ -1,6 +1,6 @@
 package org.scalatestplus.play.components
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneServerPerSuite
 import org.scalatestplus.play.FakeApplicationFactory
 import play.api.Application
@@ -15,7 +15,7 @@ import play.api.Application
  * its `port` field and the `Application` provided by its `app` field. If your `Suite` needs a different port number,
  * override `port`.
  *
- * This `TestSuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
+ * This `SuiteMixin` trait's overridden `run` method calls `start` on the `TestServer`
  * before executing the `Suite` via a call to `super.run`.
  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
  * under the key `org.scalatestplus.play.app` and to the port number provided by `port` under the key
@@ -74,7 +74,7 @@ import play.api.Application
  * `Suite`s. Annotate the nested suites with `@DoNotDiscover` and have them extend `ConfiguredServer`. Here's an example:
  *
  * <pre class="stHighlight">
- * import org.scalatest.{ DoNotDiscover, Suites, TestSuite }
+ * import org.scalatest.{ DoNotDiscover, Suites, Suite }
  * import org.scalatestplus.play.components._
  * import org.scalatestplus.play.{ ConfiguredServer, PlaySpec }
  * import play.api._
@@ -89,7 +89,7 @@ import play.api.Application
  *   new TwoSpec,
  *   new RedSpec,
  *   new BlueSpec
- * ) with OneServerPerSuiteWithComponents with TestSuite {
+ * ) with OneServerPerSuiteWithComponents with Suite {
  *   // Override fakeApplication if you need an Application with other than non-default parameters.
  *   override def components: BuiltInComponents = new BuiltInComponentsFromContext(context) with NoHttpFiltersComponents {
  *
@@ -147,7 +147,7 @@ trait OneServerPerSuiteWithComponents
     extends BaseOneServerPerSuite
     with WithApplicationComponents
     with FakeApplicationFactory {
-  this: TestSuite =>
+  this: Suite =>
 
   override def fakeApplication(): Application = newApplication
 }

--- a/module/src/main/scala/org/scalatestplus/play/components/OneServerPerTestWithComponents.scala
+++ b/module/src/main/scala/org/scalatestplus/play/components/OneServerPerTestWithComponents.scala
@@ -1,6 +1,6 @@
 package org.scalatestplus.play.components
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneServerPerTest
 import org.scalatestplus.play.FakeApplicationFactory
 import play.api.Application
@@ -10,7 +10,7 @@ import play.api.Application
  *
  * Trait that provides a new `Application` and running `TestServer` instance for each test executed in a ScalaTest `Suite`
  *
- * This `TestSuiteMixin` trait overrides ScalaTest's `withFixture` method to create a new `Application` and `TestServer`
+ * This `SuiteMixin` trait overrides ScalaTest's `withFixture` method to create a new `Application` and `TestServer`
  * before each test, and ensure they are cleaned up after the test has completed. The `Application` is available (implicitly) from
  * method `app`. The `TestServer`'s port number is available as `port` (and implicitly available as `portNumber`, wrapped
  * in a [[org.scalatestplus.play.PortNumber PortNumber]]).
@@ -63,7 +63,7 @@ trait OneServerPerTestWithComponents
     extends BaseOneServerPerTest
     with WithApplicationComponents
     with FakeApplicationFactory {
-  this: TestSuite =>
+  this: Suite =>
 
   override def fakeApplication(): Application = newApplication
 }

--- a/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneAppPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneAppPerSuite.scala
@@ -15,7 +15,7 @@
  */
 package org.scalatestplus.play.guice
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneAppPerSuite
 
 /**
@@ -25,7 +25,7 @@ import org.scalatestplus.play.BaseOneAppPerSuite
  * is made available via the `app` field defined in this trait. If your `Suite` needs a `Application` with non-default
  * parameters, override `app` to create it the way you need it.
  *
- * This `TestSuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
+ * This `SuiteMixin` trait's overridden `run` method calls `Play.start`, passing in the
  * `Application` provided by `app`, before executing the `Suite` via a call to `super.run`.
  * In addition, it places a reference to the `Application` provided by `app` into the `ConfigMap`
  * under the key `org.scalatestplus.play.app`.  This allows any nested `Suite`s to access the `Suite`'s
@@ -108,6 +108,6 @@ import org.scalatestplus.play.BaseOneAppPerSuite
  * }
  * </pre>
  */
-trait GuiceOneAppPerSuite extends BaseOneAppPerSuite with GuiceFakeApplicationFactory { this: TestSuite =>
+trait GuiceOneAppPerSuite extends BaseOneAppPerSuite with GuiceFakeApplicationFactory { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneAppPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneAppPerTest.scala
@@ -1,12 +1,12 @@
 package org.scalatestplus.play.guice
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneAppPerTest
 
 /**
  * Trait that provides a new `Application` instance for each test.
  *
- * This `TestSuiteMixin` trait's overridden `withFixture` method creates a new `Application`
+ * This `SuiteMixin` trait's overridden `withFixture` method creates a new `Application`
  * before each test and ensures it is cleaned up after the test has completed. You can
  * access the `Application` from your tests as method `app` (which is marked implicit).
  *
@@ -43,6 +43,6 @@ import org.scalatestplus.play.BaseOneAppPerTest
  * }
  * </pre>
  */
-trait GuiceOneAppPerTest extends BaseOneAppPerTest with GuiceFakeApplicationFactory { this: TestSuite =>
+trait GuiceOneAppPerTest extends BaseOneAppPerTest with GuiceFakeApplicationFactory { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneServerPerSuite.scala
@@ -1,8 +1,8 @@
 package org.scalatestplus.play.guice
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneServerPerSuite
 
-trait GuiceOneServerPerSuite extends BaseOneServerPerSuite with GuiceFakeApplicationFactory { this: TestSuite =>
+trait GuiceOneServerPerSuite extends BaseOneServerPerSuite with GuiceFakeApplicationFactory { this: Suite =>
 
 }

--- a/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/guice/GuiceOneServerPerTest.scala
@@ -1,8 +1,8 @@
 package org.scalatestplus.play.guice
 
-import org.scalatest.TestSuite
+import org.scalatest.Suite
 import org.scalatestplus.play.BaseOneServerPerTest
 
-trait GuiceOneServerPerTest extends BaseOneServerPerTest with GuiceFakeApplicationFactory { this: TestSuite =>
+trait GuiceOneServerPerTest extends BaseOneServerPerTest with GuiceFakeApplicationFactory { this: Suite =>
 
 }


### PR DESCRIPTION
this allows implementing specs to use either sync or async suites