### PR TITLE
Add wildcard import for Helpers in ScalaFunctionalTestSpec

### DIFF
--- a/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
@@ -10,11 +10,12 @@ import org.scalatest.wordspec.FixtureAnyWordSpec
 import org.scalatestplus.play._
 import play.api.http.MimeTypes
 import play.api.test._
+import play.api.test.Helpers._
 // #scalafunctionaltest-imports
 
 import play.api.mvc._
 
-import play.api.test.Helpers.{ GET => GET_REQUEST, _ }
+import play.api.test.Helpers.{ GET => GET_REQUEST }
 import play.api.Application
 import play.api.libs.ws._
 import play.api.inject.guice._


### PR DESCRIPTION
Many of the code samples in [ScalaFunctionalTestingWithScalaTest](https://www.playframework.com/documentation/2.8.x/ScalaFunctionalTestingWithScalaTest) use the Helpers implicitly and it would be helpful to include it in the import list as with the [ScalaFunctionalTestingWithSpecs2](https://www.playframework.com/documentation/2.8.x/ScalaFunctionalTestingWithSpecs2) page