### PR TITLE
Rename master branch to main

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,7 +7,7 @@ repository:
   # We don't need wiki since the documentation lives in playframework.com
   has_wiki: false
   has_downloads: true
-  default_branch: master
+  default_branch: main
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: false

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-# This file was originally copied from https://github.com/playframework/playframework/blob/master/.scalafmt.conf
+# This file was originally copied from https://github.com/playframework/playframework/blob/main/.scalafmt.conf
 align = true
 assumeStandardLibraryStripMargin = true
 danglingParentheses = true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,10 +6,10 @@ Access to `vegemite.lightbend.com`
 
 ## Process
 
-* Add the release to README.md, PR and merge to master
+* Add the release to README.md, PR and merge to main
 * Log in to `vegemite.lightbend.com`
 * `cd deploy`
-* `./release --project scalatestplus-play --branch master --tag 5.1.0` (notice: the tag is not prefixed with a 'v')
+* `./release --project scalatestplus-play --branch main --tag 5.1.0` (notice: the tag is not prefixed with a 'v')
 
 ## Future
 
@@ -25,4 +25,4 @@ Help welcome!
 ## Background
 
 More background on how Play artifacts are generally released can be
-found at https://github.com/playframework/play-meta/blob/master/releasing/play.md
+found at https://github.com/playframework/play-meta/blob/main/releasing/play.md


### PR DESCRIPTION
@SethTisue and @ihostage already renamed the `master` branch in some play repos:
* https://github.com/playframework/cachecontrol/pull/163
* https://github.com/playframework/play-file-watch/pull/136
* https://github.com/playframework/play-json/pull/598
* https://github.com/playframework/play-soap/pull/282
* https://github.com/playframework/play-ws/pull/597
* https://github.com/playframework/twirl/pull/416

Now that we are centralising configs in the [`.github`](https://github.com/playframework/.github) repo it's a good idea that all repos have the same default branch name.

To change to `main` locally (if the remote to this repo is called `upstream`):
```sh
git branch -m master main # rename master to main (actually "move")
git fetch upstream
git branch -u upstream/main main # set upstream
git remote set-head upstream -a # make sure HEAD is set correctly for this remote (autodetect)
```