### PR TITLE
Remove CrossVersion.for3Use2_13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -112,9 +112,9 @@ lazy val `scalatestplus-play` = project
       }
     },
     libraryDependencies ++= Seq(
-      ws.cross(CrossVersion.for3Use2_13),
-      (akkaHttpServer % Test).cross(CrossVersion.for3Use2_13),
-      playTest.cross(CrossVersion.for3Use2_13),
+      ws,
+      akkaHttpServer % Test,
+      playTest,
       "org.scalatest"            %% "scalatest"         % ScalatestVersion,
       "org.scalatestplus"        %% "mockito-4-6"       % ScalatestMockitoVersion,
       "org.scalatestplus"        %% "selenium-4-4"      % ScalatestSeleniumVersion,


### PR DESCRIPTION
As soon as we have a Play milestone with Scala 3 artifacts.