### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/docs/manual/working/scalaGuide/main/tests/code/mixedfixtures/ExampleSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/mixedfixtures/ExampleSpec.scala
@@ -60,7 +60,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Server {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -80,7 +80,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new HtmlUnit {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -110,7 +110,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Firefox {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -140,7 +140,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Safari {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -170,7 +170,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Chrome {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -200,7 +200,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new InternetExplorer {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()

--- a/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/NestedExampleComponentsSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/oneserverpersuite/NestedExampleComponentsSpec.scala
@@ -68,7 +68,7 @@ class NestedExampleSpec
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ChromeFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ChromeFactorySpec.scala
@@ -56,7 +56,7 @@ class ChromeFactorySpec extends UnitSpec with GuiceOneServerPerSuite with OneBro
 
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredBrowserNestedSuite.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredBrowserNestedSuite.scala
@@ -55,7 +55,7 @@ class ConfiguredBrowserNestedSuite extends UnitSpec with ConfiguredServer with C
 
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerNestedSuite.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerNestedSuite.scala
@@ -53,7 +53,7 @@ class ConfiguredServerNestedSuite extends UnitSpec with ConfiguredServer {
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerSuiteSpec.scala
@@ -75,7 +75,7 @@ class ConfiguredServerWithAllBrowsersPerSuiteNestedSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithAllBrowsersPerTestSpec.scala
@@ -62,7 +62,7 @@ class ConfiguredServerWithAllBrowsersPerTestNestedSpec extends UnitSpec with Con
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithConfiguredBrowserSpec.scala
@@ -75,7 +75,7 @@ class ConfiguredServerWithConfiguredBrowserNestedSpec extends UnitSpec with Conf
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerSuiteSpec.scala
@@ -64,7 +64,7 @@ class ConfiguredServerWithOneBrowserPerSuiteNestedSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ConfiguredServerWithOneBrowserPerTestSpec.scala
@@ -54,7 +54,7 @@ class ConfiguredServerWithOneBrowserPerTestNestedSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/EdgeFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/EdgeFactorySpec.scala
@@ -54,7 +54,7 @@ class EdgeFactorySpec extends UnitSpec with GuiceOneServerPerSuite with OneBrows
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/HtmlUnitFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/HtmlUnitFactorySpec.scala
@@ -54,7 +54,7 @@ class HtmlUnitFactorySpec extends UnitSpec with GuiceOneServerPerSuite with OneB
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/InternetExplorerFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/InternetExplorerFactorySpec.scala
@@ -58,7 +58,7 @@ class InternetExplorerFactorySpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedFixtureSpec.scala
@@ -130,7 +130,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new Server {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -175,7 +175,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new HtmlUnit {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -229,7 +229,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new Firefox {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -283,7 +283,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new Safari {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -337,7 +337,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new Chrome {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -391,7 +391,7 @@ class MixedFixtureSpec extends MixedSpec {
     "send 404 on a bad request" in new InternetExplorer {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/MixedPlaySpecSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/MixedPlaySpecSpec.scala
@@ -60,7 +60,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new Server {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -77,7 +77,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new HtmlUnit {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -104,7 +104,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new Firefox {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -131,7 +131,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new Safari {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -158,7 +158,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new Chrome {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -185,7 +185,7 @@ class MixedPlaySpecSpec extends MixedPlaySpec { thisSpec =>
     "send 404 on a bad request" in new InternetExplorer {
       override def running() = {
         import java.net._
-        val url                    = new URL("http://localhost:" + port + "/boom")
+        val url                    = new URI("http://localhost:" + port + "/boom").toURL
         val con: HttpURLConnection = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneChromeBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneChromeBrowserPerTestSpec.scala
@@ -49,7 +49,7 @@ class OneChromeBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneHtmlUnitBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneHtmlUnitBrowserPerTestSpec.scala
@@ -48,7 +48,7 @@ class OneHtmlUnitBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneInternetExplorerBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneInternetExplorerBrowserPerTestSpec.scala
@@ -48,7 +48,7 @@ class OneInternetExplorerBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneSafariBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneSafariBrowserPerTestSpec.scala
@@ -48,7 +48,7 @@ class OneSafariBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteComponentSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteComponentSpec.scala
@@ -70,7 +70,7 @@ class OneServerPerSuiteComponentSpec extends UnitSpec with OneServerPerSuiteWith
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteSpec.scala
@@ -50,7 +50,7 @@ class OneServerPerSuiteSpec extends UnitSpec with GuiceOneServerPerSuite {
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerSuiteSpec.scala
@@ -67,7 +67,7 @@ class OneServerPerSuiteWithAllBrowsersPerSuiteSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithAllBrowsersPerTestSpec.scala
@@ -55,7 +55,7 @@ class OneServerPerSuiteWithAllBrowsersPerTestSpec extends UnitSpec with GuiceOne
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithConfiguredBrowserSpec.scala
@@ -75,7 +75,7 @@ class OneServerPerSuiteWithConfiguredBrowserNestedSpec extends UnitSpec with Con
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerSuiteSpec.scala
@@ -58,7 +58,7 @@ class OneServerPerSuiteWithOneBrowserPerSuiteSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerSuiteWithOneBrowserPerTestSpec.scala
@@ -49,7 +49,7 @@ class OneServerPerSuiteWithOneBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestComponentSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestComponentSpec.scala
@@ -59,7 +59,7 @@ class OneServerPerTestComponentSpec extends UnitSpec with OneServerPerTestWithCo
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestSpec.scala
@@ -41,7 +41,7 @@ class OneServerPerTestSpec extends UnitSpec with GuiceOneServerPerTest {
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerSuiteSpec.scala
@@ -65,7 +65,7 @@ class OneServerPerTestWithAllBrowsersPerSuiteSpec extends UnitSpec with GuiceOne
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithAllBrowsersPerTestSpec.scala
@@ -56,7 +56,7 @@ class OneServerPerTestWithAllBrowsersPerTestSpec extends UnitSpec with GuiceOneS
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithConfiguredBrowserSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithConfiguredBrowserSpec.scala
@@ -75,7 +75,7 @@ class OneServerPerTestWithConfiguredBrowserNestedSpec extends UnitSpec with Conf
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerSuiteSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerSuiteSpec.scala
@@ -58,7 +58,7 @@ class OneServerPerTestWithOneBrowserPerSuiteSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerTestSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/OneServerPerTestWithOneBrowserPerTestSpec.scala
@@ -48,7 +48,7 @@ class OneServerPerTestWithOneBrowserPerTestSpec
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/SafariFactorySpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/SafariFactorySpec.scala
@@ -54,7 +54,7 @@ class SafariFactorySpec extends UnitSpec with GuiceOneServerPerSuite with OneBro
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/ServerSpecSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/ServerSpecSpec.scala
@@ -40,7 +40,7 @@ class ServerSpecSpec extends ServerSpec {
     }
     "send 404 on a bad request" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/components/oneserverpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/components/oneserverpersuite/NestedExampleSpec.scala
@@ -81,7 +81,7 @@ class NestedExampleSpec
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/allbrowserspersuite/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/allbrowserspersuite/ExampleSpec.scala
@@ -60,7 +60,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerSuite with AllBrowsersP
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/allbrowserspertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/allbrowserspertest/ExampleSpec.scala
@@ -60,7 +60,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerTest with AllBrowsersPe
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/mixedfixtures/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/mixedfixtures/ExampleSpec.scala
@@ -52,7 +52,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Server {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -69,7 +69,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new HtmlUnit {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -96,7 +96,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Firefox {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -123,7 +123,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Safari {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -150,7 +150,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new Chrome {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()
@@ -177,7 +177,7 @@ class ExampleSpec extends MixedPlaySpec {
     "send 404 on a bad request" in new InternetExplorer {
       override def running() = {
         import java.net._
-        val url = new URL("http://localhost:" + port + "/boom")
+        val url = new URI("http://localhost:" + port + "/boom").toURL
         val con = url.openConnection().asInstanceOf[HttpURLConnection]
         try con.getResponseCode mustBe 404
         finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/ExampleSpec.scala
@@ -46,7 +46,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerSuite with OneBrowserPe
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/MultiBrowserExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/MultiBrowserExampleSpec.scala
@@ -47,7 +47,7 @@ abstract class MultiBrowserExampleSpec extends PlaySpec with GuiceOneServerPerSu
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpersuite/NestedExampleSpec.scala
@@ -59,7 +59,7 @@ class BlueSpec extends PlaySpec with ConfiguredServer with ConfiguredBrowser {
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/onebrowserpertest/ExampleSpec.scala
@@ -47,7 +47,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerTest with OneBrowserPer
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpersuite/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpersuite/ExampleSpec.scala
@@ -41,7 +41,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerSuite {
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpersuite/NestedExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpersuite/NestedExampleSpec.scala
@@ -54,7 +54,7 @@ class BlueSpec extends PlaySpec with ConfiguredServer {
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()

--- a/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpertest/ExampleSpec.scala
+++ b/module/src/test/scala/org/scalatestplus/play/examples/guice/oneserverpertest/ExampleSpec.scala
@@ -45,7 +45,7 @@ class ExampleSpec extends PlaySpec with GuiceOneServerPerTest {
     }
     "provide an actual running server" in {
       import java.net._
-      val url = new URL("http://localhost:" + port + "/boum")
+      val url = new URI("http://localhost:" + port + "/boum").toURL
       val con = url.openConnection().asInstanceOf[HttpURLConnection]
       try con.getResponseCode mustBe 404
       finally con.disconnect()


### PR DESCRIPTION
deprecated since JDK 20

- https://bugs.openjdk.org/browse/JDK-8295949
- https://github.com/openjdk/jdk/commit/4338f527aa81350e3636dcfbcd2eb17ddaad3914