### PR TITLE
Upgrade Play: Random ports by default, provides better helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,6 @@ lazy val `scalatestplus-play` = project
     Compile / doc / scalacOptions := Seq("-doc-title", "ScalaTest + Play, " + version.value),
     Test / fork := true,
     Test / javaOptions ++= List(
-      "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
       "-Dwebdriver.firefox.logfile=/dev/null", // disable GeckoDriver logs polluting the CI logs
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,6 @@ lazy val `scalatestplus-play` = project
     Test / javaOptions ++= List(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
       "-Dwebdriver.firefox.logfile=/dev/null", // disable GeckoDriver logs polluting the CI logs
-      "-Dtestserver.port=0",
     ),
   )
 

--- a/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
+++ b/docs/manual/working/scalaGuide/main/tests/code/ScalaFunctionalTestSpec.scala
@@ -129,7 +129,7 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
     // #scalafunctionaltest-testwithbrowser
 
     // #scalafunctionaltest-testpaymentgateway
-    "test server logic" in new Server(appFun = { applicationWithBrowser }, httpPort = 19001) {
+    "test server logic" in new Server(appFun = { applicationWithBrowser }, port = 19001) {
       override def running() = {
         implicit val wsClient: WSClient = app.injector.instanceOf[WSClient]
 
@@ -157,7 +157,7 @@ class ScalaFunctionalTestSpec extends MixedPlaySpec with Results {
       })
       .build()
 
-    "test WS logic" in new Server(appFun = appWithRoutes, httpPort = 3333) {
+    "test WS logic" in new Server(appFun = appWithRoutes, port = 3333) {
       override def running() = {
         val wsClient = app.injector.instanceOf[WSClient]
         await(wsClient.url("http://localhost:3333").get()).status mustEqual OK

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.3
+sbt.version=1.9.0-RC3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,8 +6,8 @@ resolvers ++= Seq(
 )
 
 addSbtPlugin("com.typesafe.play" % "interplay"            % sys.props.getOrElse("interplay.version", "3.1.0-RC14"))
-addSbtPlugin("com.typesafe.play" % "sbt-plugin"           % sys.props.getOrElse("play.version", "2.9.0-M4"))
-addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.9.0-M4"))
+addSbtPlugin("com.typesafe.play" % "sbt-plugin"           % sys.props.getOrElse("play.version", "2.9.0-M5"))
+addSbtPlugin("com.typesafe.play" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "2.9.0-M5"))
 
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"    % "2.5.0")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "1.1.2")


### PR DESCRIPTION
#418 was a bit dirty. E.g. there is no need to rename the port variable.
Also, Play 2.9 latest milestone itself now by defaults uses random ports, so we can make use of that and the `runningWithPort` helper method.