### PR TITLE
https improvements

### DIFF
--- a/module/src/main/scala/org/scalatestplus/play/ServerProvider.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ServerProvider.scala
@@ -55,9 +55,9 @@ trait ServerProvider {
    * @return the configured port number, wrapped in a `PortNumber`
    */
   implicit def portNumber: PortNumber = {
-    val httpEndpoint = runningServer.endpoints.httpEndpoint
-    val port = httpEndpoint
-      .fold(throw new IllegalStateException("No HTTP port available for test server"))(_.port)
+    val port = runningServer.endpoints.httpEndpoint
+      .orElse(runningServer.endpoints.httpsEndpoint)
+      .fold(throw new IllegalStateException("Nor HTTP or HTTPS port available for test server"))(_.port)
     PortNumber(port)
   }
 }

--- a/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
+++ b/module/src/main/scala/org/scalatestplus/play/WsScalaTestClient.scala
@@ -50,7 +50,18 @@ trait WsScalaTestClient {
   def wsUrl(url: String)(implicit portNumber: PortNumber, wsClient: WSClient): WSRequest =
     doCall(url, wsClient, portNumber)
 
-  private def doCall(url: String, wsClient: WSClient, portNumber: PortNumber) = {
-    wsClient.url("http://localhost:" + portNumber.value + url)
+  /**
+   * Construct a WS request for the given relative URL.
+   *
+   * @param url the URL of the request
+   * @param secure if the request should be send via https
+   * @param portNumber the port number of the `TestServer`
+   * @param wsClient the implicit WSClient
+   */
+  def wsUrl(url: String, secure: Boolean)(implicit portNumber: PortNumber, wsClient: WSClient): WSRequest =
+    doCall(url, wsClient, portNumber, secure)
+
+  private def doCall(url: String, wsClient: WSClient, portNumber: PortNumber, secure: Boolean = false) = {
+    wsClient.url((if (secure) "https" else "http") + "://localhost:" + portNumber.value + url)
   }
 }


### PR DESCRIPTION
We fallback to https port in the play-testkit already, we need the same here.
See
- https://github.com/playframework/playframework/pull/11843
- https://github.com/playframework/playframework/blob/f74c2340962b69b389e89c67a30aa474aa6a1958/transport/server/play-server/src/main/scala/play/core/server/Server.scala#L249

Also we need to construct https urls.

All this is needed for
- https://github.com/playframework/play-grpc/pull/479