### PR TITLE
Revert "selenium-java 4.15.0 (was 4.14.1)"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import sbt.util.{ Level => _, _ }
 
 import sbt.io.Path._
 
-val SeleniumVersion          = "4.15.0"
+val SeleniumVersion          = "4.14.1"
 val SeleniumHtmlunitVersion  = "4.13.0"
 val MockitoVersion           = "4.6.1"
 val CssParserVersion         = "1.14.0"


### PR DESCRIPTION
Reverts playframework/scalatestplus-play#476

main is still the stable branch for the 7.0.x release, we did not create a 7.0.x branch yet. 
For now I never upgraded beyond 4.14.1 now, see https://github.com/playframework/playframework/pull/12371#issuecomment-1970655278