### PR TITLE
Update scalatest dependency settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,12 +100,14 @@ lazy val `scalatestplus-play` = project
       ws,
       nettyServer % Test, // Using netty for now, we can switch back to pekkoHttpServer when it has Scala 3 artifacts
       playTest,
-      "org.scalatest"           %% "scalatest"          % ScalatestVersion,
-      "org.scalatestplus"       %% "mockito-4-11"       % ScalatestMockitoVersion,
-      "org.scalatestplus"       %% "selenium-4-12"      % ScalatestSeleniumVersion,
-      "org.seleniumhq.selenium"  % "selenium-java"      % SeleniumVersion,
-      "org.seleniumhq.selenium"  % "htmlunit-driver"    % SeleniumHtmlunitVersion,
-      "net.sourceforge.htmlunit" % "htmlunit-cssparser" % CssParserVersion
+      "org.scalatest"           %% "scalatest-wordspec"     % ScalatestVersion,
+      "org.scalatest"           %% "scalatest-flatspec"     % ScalatestVersion % Test,
+      "org.scalatest"           %% "scalatest-mustmatchers" % ScalatestVersion,
+      "org.scalatestplus"       %% "mockito-4-11"           % ScalatestMockitoVersion,
+      "org.scalatestplus"       %% "selenium-4-12"          % ScalatestSeleniumVersion,
+      "org.seleniumhq.selenium"  % "selenium-java"          % SeleniumVersion,
+      "org.seleniumhq.selenium"  % "htmlunit-driver"        % SeleniumHtmlunitVersion,
+      "net.sourceforge.htmlunit" % "htmlunit-cssparser"     % CssParserVersion
     ),
     Compile / doc / scalacOptions := Seq("-doc-title", "ScalaTest + Play, " + version.value),
     doc / javacOptions            := Seq("-source", "17"),


### PR DESCRIPTION
avoid `"org.scalatest" %% "scalatest"` for reduce unnecessary dependency.

https://www.scalatest.org/release_notes/3.2.0

![scalatest](https://www.scalatest.org/assets/images/ScalaTestModularizationIn320.png)