### PR TITLE
use new intersection type syntax

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,9 +109,9 @@ lazy val `scalatestplus-play` = project
       "org.seleniumhq.selenium"  % "htmlunit-driver"        % SeleniumHtmlunitVersion,
       "net.sourceforge.htmlunit" % "htmlunit-cssparser"     % CssParserVersion
     ),
-    Compile / doc / scalacOptions := Seq("-doc-title", "ScalaTest + Play, " + version.value),
-    doc / javacOptions            := Seq("-source", "17"),
-    Test / fork                   := true,
+    Compile / doc / scalacOptions ++= Seq("-doc-title", "ScalaTest + Play, " + version.value),
+    doc / javacOptions := Seq("-source", "17"),
+    Test / fork        := true,
     Test / javaOptions ++= List(
       "-Dwebdriver.firefox.logfile=/dev/null", // disable GeckoDriver logs polluting the CI logs
     ),

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerSuite.scala
@@ -187,7 +187,7 @@ import org.scalatestplus.play.BrowserFactory.UnneededDriver
  * </pre>
  */
 trait AllBrowsersPerSuite extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience {
-  this: TestSuite with ServerProvider =>
+  this: TestSuite & ServerProvider =>
 
   /**
    * Method to provide `FirefoxProfile` for creating `FirefoxDriver`, you can override this method to

--- a/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/AllBrowsersPerTest.scala
@@ -186,7 +186,7 @@ import org.scalatestplus.selenium.WebBrowser
  * </pre>
  */
 trait AllBrowsersPerTest extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience {
-  this: TestSuite with ServerProvider =>
+  this: TestSuite & ServerProvider =>
 
   /**
    * Method to provide `FirefoxProfile` for creating `FirefoxDriver`, you can override this method to

--- a/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerSuite.scala
@@ -26,7 +26,7 @@ import play.api.Play
 /**
  * The base abstract trait for one app per suite.
  */
-trait BaseOneAppPerSuite extends TestSuiteMixin { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneAppPerSuite extends TestSuiteMixin { this: TestSuite & FakeApplicationFactory =>
 
   /**
    * An implicit instance of `Application`.

--- a/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneAppPerTest.scala
@@ -61,7 +61,7 @@ import play.api.test.Helpers
  * }
  * </pre>
  */
-trait BaseOneAppPerTest extends TestSuiteMixin with AppProvider { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneAppPerTest extends TestSuiteMixin with AppProvider { this: TestSuite & FakeApplicationFactory =>
 
   /**
    * Creates new instance of `Application` with parameters set to their defaults. Override this method if you

--- a/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerSuite.scala
@@ -135,7 +135,7 @@ import play.api.test._
  * }
  * </pre>
  */
-trait BaseOneServerPerSuite extends TestSuiteMixin with ServerProvider { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneServerPerSuite extends TestSuiteMixin with ServerProvider { this: TestSuite & FakeApplicationFactory =>
 
   /**
    * An implicit instance of `Application`.

--- a/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/BaseOneServerPerTest.scala
@@ -74,7 +74,7 @@ import org.scalatest._
  * }
  * </pre>
  */
-trait BaseOneServerPerTest extends TestSuiteMixin with ServerProvider { this: TestSuite with FakeApplicationFactory =>
+trait BaseOneServerPerTest extends TestSuiteMixin with ServerProvider { this: TestSuite & FakeApplicationFactory =>
 
   @volatile private var privateApp: Application      = _
   @volatile private var privateServer: RunningServer = _

--- a/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
+++ b/module/src/main/scala/org/scalatestplus/play/ConfiguredBrowser.scala
@@ -89,7 +89,7 @@ import org.scalatestplus.selenium.WebBrowser
  * </pre>
  */
 trait ConfiguredBrowser extends TestSuiteMixin with WebBrowser with Eventually with IntegrationPatience {
-  this: TestSuite with ServerProvider =>
+  this: TestSuite & ServerProvider =>
 
   private var configuredWebDriver: WebDriver = UninitializedDriver
 

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerSuite.scala
@@ -310,7 +310,7 @@ trait OneBrowserPerSuite
     with WebBrowser
     with Eventually
     with IntegrationPatience
-    with BrowserFactory { this: TestSuite with ServerProvider =>
+    with BrowserFactory { this: TestSuite & ServerProvider =>
 
   /**
    * An implicit instance of `WebDriver`, created by calling `createWebDriver`.

--- a/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
+++ b/module/src/main/scala/org/scalatestplus/play/OneBrowserPerTest.scala
@@ -96,7 +96,7 @@ trait OneBrowserPerTest
     with WebBrowser
     with Eventually
     with IntegrationPatience
-    with BrowserFactory { this: TestSuite with ServerProvider =>
+    with BrowserFactory { this: TestSuite & ServerProvider =>
 
   private var privateWebDriver: WebDriver = UninitializedDriver
 


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/book/types-intersection.html

prepare latest Scala 3.x

```
Welcome to Scala 3.6.4 (21.0.6, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> trait A; trait B
// defined trait A
// defined trait B
                                                                                                                                             
scala> def x: A with B = ???
1 warning found
-- [E003] Syntax Warning: ------------------------------------------------------
1 |def x: A with B = ???
  |         ^^^^
  |         with as a type operator has been deprecated; use & instead
  |
  | longer explanation available when compiling with `-explain`
def x: A & B
                                                                                                                                             
scala> def x: A & B = ???
def x: A & B
```