### PR TITLE
sbt-ci-release 1.11.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val ScalatestVersion         = "3.2.17"
 val ScalatestSeleniumVersion = ScalatestVersion + ".0"
 val ScalatestMockitoVersion  = ScalatestVersion + ".0"
 
-ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("releases")
+ThisBuild / resolvers += Resolver.sonatypeCentralSnapshots
 // To make use of Pekko snapshots uncomment following two resolvers:
 // ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 // ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
@@ -79,7 +79,6 @@ lazy val `scalatestplus-play-root` = project
   .aggregate(`scalatestplus-play`)
   .settings(commonSettings)
   .settings(
-    sonatypeProfileName   := "org.scalatestplus.play",
     mimaPreviousArtifacts := Set.empty,
     publish / skip        := true
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.7
+sbt.version=1.11.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
 resolvers ++= DefaultOptions.resolvers(snapshot = true)
-resolvers ++= Resolver
-  .sonatypeOssRepos("snapshots") // used by deploy nightlies, which publish here & use -Dplay.version
+resolvers += Resolver.sonatypeCentralSnapshots // used by deploy nightlies, which publish here & use -Dplay.version
 
 addSbtPlugin("org.playframework" % "play-docs-sbt-plugin" % sys.props.getOrElse("play.version", "3.1.0-M1"))
 
@@ -8,4 +7,4 @@ addSbtPlugin("org.scalameta"     % "sbt-scalafmt"    % "2.5.2")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "1.1.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.10.0")
 
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.2")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")


### PR DESCRIPTION
Need to publish a new milestone to make 
- https://github.com/playframework/play-samples/pull/835

work.

Because of

```
[error]         * org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0 (early-semver) is selected over 1.1.2
[error]             +- org.playframework:play_2.13:3.1.0-M2-573139bb-SNAPSHOT (depends on 2.4.0)
[error]             +- org.playframework:cachecontrol_2.13:3.1.0-M1       (depends on 1.1.2)
```
:point_down: 

```
   +-org.scalatestplus.play:scalatestplus-play_3:8.0.0-M1 // then update to 3.1.0-M2 and release
     +-org.playframework:play-ahc-ws_3:3.1.0-M1  // need to release M2 (in progress)
       +-org.playframework:play-ahc-ws-standalone_3:3.1.0-M4  // needs to be  3.1.0-M6
       | +-org.playframework:cachecontrol_3:3.1.0-M1
```